### PR TITLE
Fix: Clear manual score and save game when toggling off manual scoring

### DIFF
--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GameDetails.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GameDetails.swift
@@ -52,7 +52,9 @@ extension GamesEditor {
 
 			case .didClearManualScore:
 				state.hideNextHeaderIfNecessary()
-				return .none
+				state.game?.scoringMethod = .byFrame
+				state.game?.score = state.score?.frames.gameScore() ?? 0
+				return save(game: state.game)
 
 			case .didProvokeLock:
 				return state.presentLockedToast()


### PR DESCRIPTION
Fixes #267 

Instead of returning no effect in response to the delegate action, this ensures the game `scoringMethod` is set to `byFrame` and updates the score on the game object to reflect the latest from the frames. Then, the game is saved.