### PR TITLE
Feat: Colors of trend labels better reflect statistic trending upwards/downwards positive/negative association

### DIFF
--- a/ios/Approach/Sources/StatisticsChartsLibrary/Charts/AveragingChart.swift
+++ b/ios/Approach/Sources/StatisticsChartsLibrary/Charts/AveragingChart.swift
@@ -1,6 +1,7 @@
 import AssetsLibrary
 import Charts
 import DateTimeLibrary
+import StatisticsLibrary
 import StringsLibrary
 import SwiftUI
 
@@ -61,15 +62,18 @@ extension AveragingChart {
 		public let entries: [Entry]
 		public let minimumValue: Double
 		public let maximumValue: Double
+
+		public let preferredTrendDirection: StatisticTrendDirection?
 		public let percentDifferenceOverFullTimeSpan: Double
 
 		public var isEmpty: Bool {
 			entries.count <= 1
 		}
 
-		public init(title: String, entries: [Entry]) {
+		public init(title: String, entries: [Entry], preferredTrendDirection: StatisticTrendDirection?) {
 			self.title = title
 			self.entries = entries
+			self.preferredTrendDirection = preferredTrendDirection
 			let minimumValue = entries.min { $0.value < $1.value }?.value ?? 0
 			let maximumValue = entries.max { $0.value < $1.value }?.value ?? 0
 			let padding = (maximumValue - minimumValue) / 10
@@ -139,7 +143,8 @@ struct AveragingChartPreview: PreviewProvider {
 							value: value,
 							date: Date(timeIntervalSince1970: Double(index) * 604800.0)
 						)
-					}
+					},
+					preferredTrendDirection: .downwards
 				)
 			)
 
@@ -152,7 +157,8 @@ struct AveragingChartPreview: PreviewProvider {
 							value: value,
 							date: Date(timeIntervalSince1970: Double(index) * 604800.0)
 						)
-					}
+					},
+					preferredTrendDirection: .upwards
 				),
 				style: .init(hideXAxis: true)
 			)

--- a/ios/Approach/Sources/StatisticsChartsLibrary/Charts/PercentageChart.swift
+++ b/ios/Approach/Sources/StatisticsChartsLibrary/Charts/PercentageChart.swift
@@ -1,6 +1,7 @@
 import AssetsLibrary
 import Charts
 import DateTimeLibrary
+import StatisticsLibrary
 import StringsLibrary
 import SwiftUI
 
@@ -87,16 +88,24 @@ extension PercentageChart {
 		public let title: String
 		public let entries: [Entry]
 		public let isAccumulating: Bool
+
+		public let preferredTrendDirection: StatisticTrendDirection?
 		public let percentDifferenceOverFullTimeSpan: Double?
 
 		public var isEmpty: Bool {
 			entries.isEmpty || (isAccumulating && entries.count == 1)
 		}
 
-		public init(title: String, entries: [Entry], isAccumulating: Bool) {
+		public init(
+			title: String,
+			entries: [Entry],
+			isAccumulating: Bool,
+			preferredTrendDirection: StatisticTrendDirection?
+		) {
 			self.title = title
 			self.entries = entries
 			self.isAccumulating = isAccumulating
+			self.preferredTrendDirection = preferredTrendDirection
 
 			if isAccumulating {
 				let firstValue = entries.first?.percentage ?? 0
@@ -192,7 +201,8 @@ struct PercentageChartPreview: PreviewProvider {
 								timeRange: 604800.0
 							)
 					},
-					isAccumulating: false
+					isAccumulating: false,
+					preferredTrendDirection: .upwards
 				)
 			)
 
@@ -208,7 +218,8 @@ struct PercentageChartPreview: PreviewProvider {
 								timeRange: 604800.0
 							)
 					},
-					isAccumulating: true
+					isAccumulating: true,
+					preferredTrendDirection: .downwards
 				)
 			)
 		}

--- a/ios/Approach/Sources/StatisticsChartsMocksLibrary/AveragingChart+Mock.swift
+++ b/ios/Approach/Sources/StatisticsChartsMocksLibrary/AveragingChart+Mock.swift
@@ -17,7 +17,8 @@ extension AveragingChart.Data {
 					value: average,
 					date: Calendar.current.date(byAdding: .weekOfYear, value: index, to: startDate)!
 				)
-			}
+			},
+			preferredTrendDirection: .upwards
 		)
 	}
 
@@ -32,7 +33,8 @@ extension AveragingChart.Data {
 					value: average,
 					date: Calendar.current.date(byAdding: .weekOfYear, value: index, to: startDate)!
 				)
-			}
+			},
+			preferredTrendDirection: .upwards
 		)
 	}
 

--- a/ios/Approach/Sources/StatisticsChartsMocksLibrary/PercentageChart+Mock.swift
+++ b/ios/Approach/Sources/StatisticsChartsMocksLibrary/PercentageChart+Mock.swift
@@ -36,7 +36,8 @@ extension PercentageChart.Data {
 						timeRange: 604800.0
 					)
 				},
-			isAccumulating: isAccumulating
+			isAccumulating: isAccumulating,
+			preferredTrendDirection: .upwards
 		)
 	}
 

--- a/ios/Approach/Sources/StatisticsLibrary/Statistic.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Statistic.swift
@@ -9,6 +9,7 @@ public protocol Statistic {
 	static var category: StatisticCategory { get }
 	static var supportsAggregation: Bool { get }
 	static var supportsWidgets: Bool { get }
+	static var preferredTrendDirection: StatisticTrendDirection? { get }
 
 	var formattedValue: String { get }
 	var isEmpty: Bool { get }
@@ -45,6 +46,13 @@ public enum StatisticCategory: CaseIterable, CustomStringConvertible {
 		case .series: return Strings.Statistics.Categories.Series.title
 		}
 	}
+}
+
+// MARK: - Trend
+
+public enum StatisticTrendDirection {
+	case upwards
+	case downwards
 }
 
 // MARK: - Trackable Per Frame

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Aces.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Aces.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Aces: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.aces }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var aces = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+AcesSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+AcesSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct AcesSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.acesSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.aces }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+ChopOffs.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+ChopOffs.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct ChopOffs: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.chopOffs }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var chopOffs = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+ChopOffsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+ChopOffsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct ChopOffsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.chopOffsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.chopOffs }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+HeadPins.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+HeadPins.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct HeadPins: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.headPins }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var headPins = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+HeadPinsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+HeadPinsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct HeadPinsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.headPinsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.headPins }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftChopOffs.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftChopOffs.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftChopOffs: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.leftChopOffs }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var leftChopOffs = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftChopOffsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftChopOffsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftChopOffsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.leftChopOffsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.leftChopOffs }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftSplits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftSplits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftSplits: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.leftSplits }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var leftSplits = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftSplitsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftSplitsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftSplitsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.leftSplitsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.leftSplits }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftTwelves.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftTwelves.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftTwelves: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.leftTwelves }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var leftTwelves = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftTwelvesSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftTwelvesSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftTwelvesSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.leftTwelvesSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.leftTwelves }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Lefts.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Lefts.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Lefts: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.lefts }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var lefts = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+LeftsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.leftsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.lefts }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightChopOffs.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightChopOffs.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightChopOffs: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.rightChopOffs }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var rightChopOffs = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightChopOffsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightChopOffsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightChopOffsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.rightChopOffsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.rightChopOffs }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightSplits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightSplits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightSplits: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.rightSplits }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var rightSplits = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightSplitsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightSplitsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightSplitsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.rightSplitsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.rightSplits }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightTwelves.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightTwelves.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightTwelves: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.rightTwelves }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var rightTwelves = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightTwelvesSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightTwelvesSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightTwelvesSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.rightTwelvesSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.rightTwelves }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Rights.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Rights.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Rights: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.rights }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var rights = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+RightsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.rightsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.rights }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Splits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Splits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Splits: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.splits }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var splits = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+SplitsSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+SplitsSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct SplitsSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.splitsSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.splits }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Twelves.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+Twelves.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Twelves: Statistic, TrackablePerFirstRoll, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.twelves }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var twelves = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+TwelvesSpared.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/FirstRoll/Statistics+TwelvesSpared.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct TwelvesSpared: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.twelvesSpared }
 		public static var category: StatisticCategory { .onFirstRoll }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.twelves }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Fouls/Statistics+Fouls.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Fouls/Statistics+Fouls.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Fouls: Statistic, TrackablePerFrame, PercentageStatistic {
 		public static var title: String { Strings.Statistics.Title.fouls }
 		public static var category: StatisticCategory { .fouls }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		public static var numeratorTitle: String { Strings.Statistics.Title.fouls }
 		public static var denominatorTitle: String { Strings.Statistics.Title.totalRolls }

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesLost.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesLost.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct MatchesLost: Statistic, TrackablePerGame, PercentageStatistic {
 		public static var title: String { Strings.Statistics.Title.matchesLost }
 		public static var category: StatisticCategory { .matchPlayResults }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		public static var numeratorTitle: String { Strings.Statistics.Title.matchesLost }
 		public static var denominatorTitle: String { Strings.Statistics.Title.matchesPlayed }

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesPlayed.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesPlayed.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct MatchesPlayed: Statistic, TrackablePerGame, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.matchesPlayed }
 		public static var category: StatisticCategory { .matchPlayResults }
+		public static var preferredTrendDirection: StatisticTrendDirection? { nil }
 
 		private var matchesPlayed = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesTied.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesTied.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct MatchesTied: Statistic, TrackablePerGame, PercentageStatistic {
 		public static var title: String { Strings.Statistics.Title.matchesTied }
 		public static var category: StatisticCategory { .matchPlayResults }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		public static var numeratorTitle: String { Strings.Statistics.Title.matchesTied }
 		public static var denominatorTitle: String { Strings.Statistics.Title.matchesPlayed }

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesWon.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/MatchPlay/Statistics+MatchesWon.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct MatchesWon: Statistic, TrackablePerGame, PercentageStatistic {
 		public static var title: String { Strings.Statistics.Title.matchesWon }
 		public static var category: StatisticCategory { .matchPlayResults }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var numeratorTitle: String { Strings.Statistics.Title.matchesWon }
 		public static var denominatorTitle: String { Strings.Statistics.Title.matchesPlayed }

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+GameAverage.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+GameAverage.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct GameAverage: Statistic, TrackablePerGame, AveragingStatistic {
 		public static var title: String { Strings.Statistics.Title.gameAverage }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		private var totalPinFall = 0
 		private var gamesPlayed = 0

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+HighSingle.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+HighSingle.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct HighSingle: Statistic, TrackablePerGame, HighestOfStatistic {
 		public static var title: String { Strings.Statistics.Title.highSingle }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		private var highSingle = 0
 		public var highest: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+LeftOfMiddleHits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+LeftOfMiddleHits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct LeftOfMiddleHits: Statistic, TrackablePerFirstRoll, FirstRollStatistic {
 		public static var title: String { Strings.Statistics.Title.leftOfMiddleHits }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		public var totalRolls = 0
 		private var leftOfMiddleHits = 0

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+MiddleHits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+MiddleHits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct MiddleHits: Statistic, TrackablePerFirstRoll, FirstRollStatistic {
 		public static var title: String { Strings.Statistics.Title.middleHits }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public var totalRolls = 0
 		private var middleHits = 0

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+NumberOfGames.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+NumberOfGames.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct NumberOfGames: Statistic, TrackablePerGame, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.numberOfGames }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { nil }
 
 		private var numberOfGames = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+RightOfMiddleHits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+RightOfMiddleHits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct RightOfMiddleHits: Statistic, TrackablePerFirstRoll, FirstRollStatistic {
 		public static var title: String { Strings.Statistics.Title.rightOfMiddleHits }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		public var totalRolls = 0
 		private var rightOfMiddleHits = 0

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+SpareConversions.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+SpareConversions.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct SpareConversions: Statistic, TrackablePerSecondRoll, SecondRollStatistic {
 		public static var title: String { Strings.Statistics.Title.spareConversions }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var denominatorTitle: String { Strings.Statistics.Title.spareChances }
 

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+StrikeMiddleHits.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+StrikeMiddleHits.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct StrikeMiddleHits: Statistic, TrackablePerFrame, PercentageStatistic {
 		public static var title: String { Strings.Statistics.Title.strikeMiddleHits }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public static var numeratorTitle: String { Strings.Statistics.Title.strikeMiddleHits }
 		public static var denominatorTitle: String { Strings.Statistics.Title.middleHits }

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+Strikes.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+Strikes.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct Strikes: Statistic, TrackablePerFirstRoll, FirstRollStatistic {
 		public static var title: String { Strings.Statistics.Title.strikes }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		public var totalRolls = 0
 		private var strikes = 0

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+TotalPinfall.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+TotalPinfall.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct TotalPinfall: Statistic, TrackablePerGame, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.totalPinfall }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { nil }
 
 		private var totalPinfall = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+TotalRolls.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Overall/Statistics+TotalRolls.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct TotalRolls: Statistic, TrackablePerFrame, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.totalRolls }
 		public static var category: StatisticCategory { .overall }
+		public static var preferredTrendDirection: StatisticTrendDirection? { nil }
 
 		private var totalRolls = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/PinsLeftOnDeck/Statistics+AveragePinsLeftOnDeck.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/PinsLeftOnDeck/Statistics+AveragePinsLeftOnDeck.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct AveragePinsLeftOnDeck: Statistic, TrackablePerFrame, AveragingStatistic {
 		public static var title: String { Strings.Statistics.Title.averagePinsLeftOnDeck }
 		public static var category: StatisticCategory { .pinsLeftOnDeck }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .downwards }
 
 		private var totalPinsLeftOnDeck = 0
 		private var gamesPlayed: Set<Game.ID> = []

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/PinsLeftOnDeck/Statistics+TotalPinsLeftOnDeck.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/PinsLeftOnDeck/Statistics+TotalPinsLeftOnDeck.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct TotalPinsLeftOnDeck: Statistic, TrackablePerFrame, CountingStatistic {
 		public static var title: String { Strings.Statistics.Title.totalPinsLeftOnDeck }
 		public static var category: StatisticCategory { .pinsLeftOnDeck }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .none }
 
 		private var totalPinsLeftOnDeck = 0
 		public var count: Int {

--- a/ios/Approach/Sources/StatisticsLibrary/Trackable/Series/Statistics+HighSeriesOf3.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Trackable/Series/Statistics+HighSeriesOf3.swift
@@ -5,6 +5,7 @@ extension Statistics {
 	public struct HighSeriesOf3: Statistic, TrackablePerSeries, HighestOfStatistic {
 		public static var title: String { Strings.Statistics.Title.highSeriesOf3 }
 		public static var category: StatisticCategory { .series }
+		public static var preferredTrendDirection: StatisticTrendDirection? { .upwards }
 
 		private var highSeries = 0
 		public var highest: Int {

--- a/ios/Approach/Sources/StatisticsRepository/Aggregation/ChartBuilder.swift
+++ b/ios/Approach/Sources/StatisticsRepository/Aggregation/ChartBuilder.swift
@@ -73,7 +73,8 @@ struct ChartBuilder {
 				title: statisticType.title,
 				entries: entries.sortedByDate()
 					.compactMap(as: AveragingStatistic.self)
-					.map { .init(id: uuid(), value: $1.average, date: $0) }
+					.map { .init(id: uuid(), value: $1.average, date: $0) },
+				preferredTrendDirection: statisticType.preferredTrendDirection
 			))
 		} else if statisticType is CountingStatistic.Type {
 			return .counting(.init(
@@ -97,7 +98,8 @@ struct ChartBuilder {
 				entries: entries.sortedByDate()
 					.compactMap(as: PercentageStatistic.self)
 					.map { .init(id: uuid(), numerator: $1.numerator, denominator: $1.denominator, date: $0, timeRange: timePeriod) },
-				isAccumulating: aggregation == .accumulate
+				isAccumulating: aggregation == .accumulate,
+				preferredTrendDirection: statisticType.preferredTrendDirection
 			))
 		}
 

--- a/ios/Approach/Sources/StatisticsWidgetsLibrary/Widgets/StatisticsWidget+Widget.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLibrary/Widgets/StatisticsWidget+Widget.swift
@@ -50,9 +50,7 @@ extension StatisticsWidget {
 				)
 				.labeledContentStyle(WidgetLabeledContentStyle(
 					labelColor: Asset.Colors.Charts.Averaging.Compact.axes,
-					contentColor: data.percentDifferenceOverFullTimeSpan > 0
-					? Asset.Colors.Charts.Averaging.Compact.positiveChange
-					: Asset.Colors.Charts.Averaging.Compact.negativeChange
+					contentColor: data.trendColor
 				))
 			}
 		}
@@ -77,9 +75,7 @@ extension StatisticsWidget {
 					)
 					.labeledContentStyle(WidgetLabeledContentStyle(
 						labelColor: Asset.Colors.Charts.Percentage.Compact.axes,
-						contentColor: percentageDifferenceOverTime > 0
-							? Asset.Colors.Charts.Percentage.Compact.positiveChange
-							: Asset.Colors.Charts.Percentage.Compact.negativeChange
+						contentColor: data.trendColor
 					))
 				} else {
 					Text(String(describing: configuration.timeline))
@@ -171,6 +167,41 @@ extension StatisticsWidget {
 				Spacer()
 			}
 			.contentShape(Rectangle())
+		}
+	}
+}
+
+extension AveragingChart.Data {
+	var trendColor: ColorAsset {
+		switch preferredTrendDirection {
+		case .upwards:
+			return percentDifferenceOverFullTimeSpan > 0
+				? Asset.Colors.Charts.Averaging.Compact.positiveChange
+				: Asset.Colors.Charts.Averaging.Compact.negativeChange
+		case .downwards:
+			return percentDifferenceOverFullTimeSpan < 0
+				? Asset.Colors.Charts.Averaging.Compact.positiveChange
+				: Asset.Colors.Charts.Averaging.Compact.negativeChange
+		case .none:
+			return Asset.Colors.Charts.Averaging.Compact.axes
+		}
+	}
+}
+
+extension PercentageChart.Data {
+	var trendColor: ColorAsset {
+		guard let percentDifferenceOverFullTimeSpan else { return Asset.Colors.Charts.Percentage.Compact.axes }
+		switch preferredTrendDirection {
+		case .upwards:
+			return percentDifferenceOverFullTimeSpan > 0
+				? Asset.Colors.Charts.Percentage.Compact.positiveChange
+				: Asset.Colors.Charts.Percentage.Compact.negativeChange
+		case .downwards:
+			return percentDifferenceOverFullTimeSpan < 0
+				? Asset.Colors.Charts.Percentage.Compact.positiveChange
+				: Asset.Colors.Charts.Percentage.Compact.negativeChange
+		case .none:
+			return Asset.Colors.Charts.Percentage.Compact.axes
 		}
 	}
 }


### PR DESCRIPTION
Fixes #278 

Adds a new property to `Statistic`: `preferredTrendDirection` which indicates if a particular stat trending `upwards` or `downwards` is preferable