### PR TITLE
Display prompt to set lanes for all games

### DIFF
--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Alert.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Alert.swift
@@ -1,0 +1,41 @@
+import ComposableArchitecture
+import StringsLibrary
+
+extension GamesEditor {
+	func reduce(into state: inout State, duplicateLanesAction: GamesEditor.Destination.AlertAction) -> Effect<Action> {
+		switch duplicateLanesAction {
+		case .confirmDuplicateLanes:
+			let currentGame = state.currentGameId
+			let otherGames = state.bowlerGameIds.flatMap { $0.value }.filter { $0 != currentGame }
+			return .run { _ in
+				try await games.duplicateLanes(from: currentGame, toAllGames: otherGames)
+			} catch: { error, send in
+				await send(.internal(.didDuplicateLanes(.failure(error))))
+			}
+
+		case .didDismiss:
+			state.destination = .gameDetails(.init(
+				gameId: state.currentGameId,
+				nextHeaderElement: state.nextHeaderElement,
+				didChangeBowler: false
+			))
+			return .none
+		}
+	}
+}
+
+extension AlertState where Action == GamesEditor.Destination.AlertAction {
+	static let duplicateLanes = Self {
+		TextState(Strings.Game.Editor.Fields.Alley.Lanes.Duplicate.title)
+	} actions: {
+		ButtonState(action: .confirmDuplicateLanes) {
+			TextState(Strings.Game.Editor.Fields.Alley.Lanes.Duplicate.copyToAll)
+		}
+
+		ButtonState(role: .cancel, action: .didDismiss) {
+			TextState(Strings.Game.Editor.Fields.Alley.Lanes.Duplicate.dismiss)
+		}
+	} message: {
+		TextState(Strings.Game.Editor.Fields.Alley.Lanes.Duplicate.message)
+	}
+}

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Destination.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Destination.swift
@@ -9,9 +9,8 @@ import ResourcePickerLibrary
 import SharingFeature
 
 extension GamesEditor {
-	public struct Destination: Reducer {
+	public struct SheetsDestination: Reducer {
 		public enum State: Equatable {
-			case gameDetails(GameDetails.State)
 			case settings(GamesSettings.State)
 			case opponentPicker(ResourcePicker<Bowler.Opponent, AlwaysEqual<Void>>.State)
 			case gearPicker(ResourcePicker<Gear.Summary, AlwaysEqual<Void>>.State)
@@ -21,7 +20,6 @@ extension GamesEditor {
 		}
 
 		public enum Action: Equatable {
-			case gameDetails(GameDetails.Action)
 			case settings(GamesSettings.Action)
 			case opponentPicker(ResourcePicker<Bowler.Opponent, AlwaysEqual<Void>>.Action)
 			case gearPicker(ResourcePicker<Gear.Summary, AlwaysEqual<Void>>.Action)
@@ -35,9 +33,6 @@ extension GamesEditor {
 		@Dependency(\.lanes) var lanes
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.gameDetails, action: /Action.gameDetails) {
-				GameDetails()
-			}
 			Scope(state: /State.settings, action: /Action.settings) {
 				GamesSettings()
 			}
@@ -55,6 +50,34 @@ extension GamesEditor {
 			}
 			Scope(state: /State.sharing, action: /Action.sharing) {
 				Sharing()
+			}
+		}
+	}
+
+	public struct Destination: Reducer {
+		public enum State: Equatable {
+			case gameDetails(GameDetails.State)
+			case duplicateLanesAlert(AlertState<AlertAction>)
+			case sheets(SheetsDestination.State)
+		}
+
+		public enum Action: Equatable {
+			case gameDetails(GameDetails.Action)
+			case duplicateLanesAlert(AlertAction)
+			case sheets(SheetsDestination.Action)
+		}
+
+		public enum AlertAction: Equatable {
+			case confirmDuplicateLanes
+			case didDismiss
+		}
+
+		public var body: some ReducerOf<Self> {
+			Scope(state: /State.gameDetails, action: /Action.gameDetails) {
+				GameDetails()
+			}
+			Scope(state: /State.sheets, action: /Action.sheets) {
+				SheetsDestination()
 			}
 		}
 	}

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GameDetails.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GameDetails.swift
@@ -11,29 +11,29 @@ extension GamesEditor {
 			switch delegateAction {
 			case .didRequestOpponentPicker:
 				let opponent = Set([state.game?.matchPlay?.opponent?.id].compactMap { $0 })
-				state.destination = .opponentPicker(.init(
+				state.destination = .sheets(.opponentPicker(.init(
 					selected: opponent,
 					query: .init(()),
 					limit: 1,
 					showsCancelHeaderButton: false
-				))
+				)))
 				return .none
 
 			case .didRequestGearPicker:
 				let gear = Set(state.game?.gear.map(\.id) ?? [])
-				state.destination = .gearPicker(.init(
+				state.destination = .sheets(.gearPicker(.init(
 					selected: gear,
 					query: .init(())
-				))
+				)))
 				return .none
 
 			case .didRequestLanePicker:
 				guard let alleyId = state.game?.series.alley?.id else { return .none }
 				let lanes = Set(state.game?.lanes.map(\.id) ?? [])
-				state.destination = .lanePicker(.init(
+				state.destination = .sheets(.lanePicker(.init(
 					selected: lanes,
 					query: alleyId
-				))
+				)))
 				return .none
 
 			case let .didEditMatchPlay(.success(matchPlay)):

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GamesHeader.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GamesHeader.swift
@@ -23,16 +23,16 @@ extension GamesEditor {
 
 			case .didOpenSettings:
 				guard let bowlers = state.bowlers else { return .none }
-				state.destination = .settings(.init(
+				state.destination = .sheets(.settings(.init(
 					bowlers: bowlers,
 					currentBowlerId: state.currentBowlerId,
 					numberOfGames: state.numberOfGames,
 					gameIndex: state.currentGameIndex
-				))
+				)))
 				return .none
 
 			case .didShareGame:
-				state.destination = .sharing(.init(dataSource: .games([state.currentGameId])))
+				state.destination = .sheets(.sharing(.init(dataSource: .games([state.currentGameId]))))
 				return .none
 			}
 

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+RollEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+RollEditor.swift
@@ -34,11 +34,11 @@ extension GamesEditor {
 
 			case .didRequestBallPicker:
 				let bowlingBall = state.frames?[state.currentFrameIndex].rolls[state.currentRollIndex].bowlingBall?.id
-				state.destination = .ballPicker(.init(
+				state.destination = .sheets(.ballPicker(.init(
 					selected: Set([bowlingBall].compactMap { $0 }),
 					query: .init(()),
 					limit: 1
-				))
+				)))
 				return .none
 
 			case .didEditRoll:

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Utilities.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Utilities.swift
@@ -87,7 +87,7 @@ extension GamesEditor.State {
 		case var .gameDetails(details):
 			details.nextHeaderElement = _nextHeaderElement
 			destination = .gameDetails(details)
-		case .ballPicker, .gearPicker, .lanePicker, .opponentPicker, .settings, .sharing, .none:
+		case .duplicateLanesAlert, .sheets, .none:
 			break
 		}
 }

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
@@ -312,7 +312,9 @@ public struct GamesEditor: Reducer {
 						))
 						state.didChangeBowler = false
 					case .sheets, .duplicateLanesAlert:
-						state.destination = nil
+						if state.currentGameId != game.id {
+							state.destination = nil
+						}
 					}
 					state.game = game
 					state.elementsRefreshing.remove(.game)

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditorView.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditorView.swift
@@ -131,60 +131,69 @@ public struct GamesEditorView: View {
 			}
 		})
 		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.sheet(
+		.alert(
 			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesEditor.Destination.State.ballPicker,
-			action: GamesEditor.Destination.Action.ballPicker,
-			onDismiss: { store.send(.internal(.didDismissOpenSheet)) },
-			content: { (store: StoreOf<ResourcePicker<Gear.Summary, AlwaysEqual<Void>>>) in
-				ballPicker(store: store)
-			}
+			state: /GamesEditor.Destination.State.duplicateLanesAlert,
+			action: GamesEditor.Destination.Action.duplicateLanesAlert
 		)
 		.sheet(
 			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesEditor.Destination.State.lanePicker,
-			action: GamesEditor.Destination.Action.lanePicker,
-			onDismiss: { store.send(.internal(.didDismissOpenSheet)) },
-			content: { (store: StoreOf<ResourcePicker<Lane.Summary, Alley.ID>>) in
-				lanePicker(store: store)
+			state: /GamesEditor.Destination.State.sheets,
+			action: GamesEditor.Destination.Action.sheets
+		) {
+			SwitchStore($0) { state in
+				switch state {
+				case .ballPicker:
+					CaseLet(
+						/GamesEditor.SheetsDestination.State.ballPicker,
+						action: GamesEditor.SheetsDestination.Action.ballPicker
+					) {
+						ballPicker(store: $0)
+							.onDisappear { store.send(.internal(.didDismissOpenSheet(.ballPicker))) }
+					}
+				case .lanePicker:
+					CaseLet(
+						/GamesEditor.SheetsDestination.State.lanePicker,
+						action: GamesEditor.SheetsDestination.Action.lanePicker
+					) {
+						lanePicker(store: $0)
+							.onDisappear { store.send(.internal(.didDismissOpenSheet(.lanePicker))) }
+					}
+				case .opponentPicker:
+					CaseLet(
+						/GamesEditor.SheetsDestination.State.opponentPicker,
+						action: GamesEditor.SheetsDestination.Action.opponentPicker
+					) {
+						opponentPicker(store: $0)
+							.onDisappear { store.send(.internal(.didDismissOpenSheet(.opponentPicker))) }
+					}
+				case .gearPicker:
+					CaseLet(
+						/GamesEditor.SheetsDestination.State.gearPicker,
+						action: GamesEditor.SheetsDestination.Action.gearPicker
+					) {
+						gearPicker(store: $0)
+							.onDisappear { store.send(.internal(.didDismissOpenSheet(.gearPicker))) }
+					}
+				case .settings:
+					CaseLet(
+						/GamesEditor.SheetsDestination.State.settings,
+						action: GamesEditor.SheetsDestination.Action.settings
+					) {
+						gamesSettings(store: $0)
+							.onDisappear { store.send(.internal(.didDismissOpenSheet(.settings))) }
+					}
+				case .sharing:
+					CaseLet(
+						/GamesEditor.SheetsDestination.State.sharing,
+						action: GamesEditor.SheetsDestination.Action.sharing
+					) {
+						sharing(store: $0)
+							.onDisappear { store.send(.internal(.didDismissOpenSheet(.sharing))) }
+					}
+				}
 			}
-		)
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesEditor.Destination.State.opponentPicker,
-			action: GamesEditor.Destination.Action.opponentPicker,
-			onDismiss: { store.send(.internal(.didDismissOpenSheet)) },
-			content: { (store: StoreOf<ResourcePicker<Bowler.Opponent, AlwaysEqual<Void>>>) in
-				opponentPicker(store: store)
-			}
-		)
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesEditor.Destination.State.gearPicker,
-			action: GamesEditor.Destination.Action.gearPicker,
-			onDismiss: { store.send(.internal(.didDismissOpenSheet)) },
-			content: { (store: StoreOf<ResourcePicker<Gear.Summary, AlwaysEqual<Void>>>) in
-				gearPicker(store: store)
-			}
-		)
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesEditor.Destination.State.settings,
-			action: GamesEditor.Destination.Action.settings,
-			onDismiss: { store.send(.internal(.didDismissOpenSheet)) },
-			content: { (store: StoreOf<GamesSettings>) in
-				gamesSettings(store: store)
-			}
-		)
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesEditor.Destination.State.sharing,
-			action: GamesEditor.Destination.Action.sharing,
-			onDismiss: { store.send(.internal(.didDismissOpenSheet)) },
-			content: { (store: StoreOf<Sharing>) in
-				sharing(store: store)
-			}
-		)
+		}
 	}
 
 	private func gameDetails(

--- a/ios/Approach/Sources/GamesEditorFeature/Manage/GamesSettings.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Manage/GamesSettings.swift
@@ -67,10 +67,16 @@ public struct GamesSettings: Reducer {
 					return .run { _ in await dismiss() }
 
 				case let .didSwitchGame(index):
-					return .send(.delegate(.switchedGame(to: index)))
+					return .concatenate(
+						.send(.delegate(.switchedGame(to: index))),
+						.run { _ in await dismiss() }
+					)
 
 				case let .didSwitchBowler(id):
-					return .send(.delegate(.switchedBowler(to: id)))
+					return .concatenate(
+						.send(.delegate(.switchedBowler(to: id))),
+						.run { _ in await dismiss() }
+					)
 
 				case let .didMoveBowlers(source, destination):
 					return .send(.delegate(.movedBowlers(source: source, destination: destination)))

--- a/ios/Approach/Sources/GamesRepository/GamesRepository+Live.swift
+++ b/ios/Approach/Sources/GamesRepository/GamesRepository+Live.swift
@@ -182,6 +182,20 @@ extension GamesRepository: DependencyKey {
 				_ = try await database.writer().write {
 					try Game.Database.deleteOne($0, id: id)
 				}
+			},
+			duplicateLanes: { source, destinations in
+				try await database.writer().write {
+					let lanesForGame = try GameLane.Database
+						.filter(GameLane.Database.Columns.gameId == source)
+						.fetchAll($0)
+
+					for game in destinations {
+						for lane in lanesForGame {
+							let gameLane = GameLane.Database(gameId: game, laneId: lane.laneId)
+							try gameLane.upsert($0)
+						}
+					}
+				}
 			}
 		)
 	}()

--- a/ios/Approach/Sources/GamesRepositoryInterface/GamesRepository+Interface.swift
+++ b/ios/Approach/Sources/GamesRepositoryInterface/GamesRepository+Interface.swift
@@ -17,6 +17,7 @@ public struct GamesRepository: Sendable {
 	public var findIndex: @Sendable (Game.ID) async throws -> Game.Indexed?
 	public var update: @Sendable (Game.Edit) async throws -> Void
 	public var delete: @Sendable (Game.ID) async throws -> Void
+	public var duplicateLanes: @Sendable (Game.ID, [Game.ID]) async throws -> Void
 
 	public init(
 		list: @escaping @Sendable (Series.ID, Game.Ordering) -> AsyncThrowingStream<[Game.List], Error>,
@@ -27,7 +28,8 @@ public struct GamesRepository: Sendable {
 		observe: @escaping @Sendable (Game.ID) -> AsyncThrowingStream<Game.Edit?, Error>,
 		findIndex: @escaping @Sendable (Game.ID) async throws -> Game.Indexed?,
 		update: @escaping @Sendable (Game.Edit) async throws -> Void,
-		delete: @escaping @Sendable (Game.ID) async throws -> Void
+		delete: @escaping @Sendable (Game.ID) async throws -> Void,
+		duplicateLanes: @escaping @Sendable (Game.ID, [Game.ID]) async throws -> Void
 	) {
 		self.list = list
 		self.summariesList = summariesList
@@ -38,6 +40,7 @@ public struct GamesRepository: Sendable {
 		self.findIndex = findIndex
 		self.update = update
 		self.delete = delete
+		self.duplicateLanes = duplicateLanes
 	}
 
 	public func seriesGames(forId: Series.ID, ordering: Game.Ordering) -> AsyncThrowingStream<[Game.List], Error> {
@@ -54,6 +57,10 @@ public struct GamesRepository: Sendable {
 	public func matches(against opponent: Bowler.ID) -> AsyncThrowingStream<[Game.ListMatch], Error> {
 		self.matchesAgainstOpponent(opponent)
 	}
+
+	public func duplicateLanes(from source: Game.ID, toAllGames allGames: [Game.ID]) async throws {
+		try await self.duplicateLanes(source, allGames)
+	}
 }
 
 extension GamesRepository: TestDependencyKey {
@@ -66,7 +73,8 @@ extension GamesRepository: TestDependencyKey {
 		observe: { _ in unimplemented("\(Self.self).observeChanges") },
 		findIndex: { _ in unimplemented("\(Self.self).findIndex") },
 		update: { _ in unimplemented("\(Self.self).update") },
-		delete: { _ in unimplemented("\(Self.self).delete") }
+		delete: { _ in unimplemented("\(Self.self).delete") },
+		duplicateLanes: { _, _ in unimplemented("\(Self.self).duplicateLanes") }
 	)
 }
 

--- a/ios/Approach/Sources/StringsLibrary/Strings+Generated.swift
+++ b/ios/Approach/Sources/StringsLibrary/Strings+Generated.swift
@@ -450,6 +450,16 @@ public enum Strings {
             public static let manageLanes = Strings.tr("Localizable", "game.editor.fields.alley.lanes.manageLanes", fallback: "Manage lanes")
             /// Set specific lanes?
             public static let selectLanes = Strings.tr("Localizable", "game.editor.fields.alley.lanes.selectLanes", fallback: "Set specific lanes?")
+            public enum Duplicate {
+              /// Yes, copy to all
+              public static let copyToAll = Strings.tr("Localizable", "game.editor.fields.alley.lanes.duplicate.copyToAll", fallback: "Yes, copy to all")
+              /// No, I might change lanes
+              public static let dismiss = Strings.tr("Localizable", "game.editor.fields.alley.lanes.duplicate.dismiss", fallback: "No, I might change lanes")
+              /// If you're bowling all your games on the same lanes tonight, easily copy the lanes you just set to the rest of the games. You can change these later.
+              public static let message = Strings.tr("Localizable", "game.editor.fields.alley.lanes.duplicate.message", fallback: "If you're bowling all your games on the same lanes tonight, easily copy the lanes you just set to the rest of the games. You can change these later.")
+              /// Copy lanes to all games?
+              public static let title = Strings.tr("Localizable", "game.editor.fields.alley.lanes.duplicate.title", fallback: "Copy lanes to all games?")
+            }
           }
         }
         public enum ExcludeFromStatistics {

--- a/ios/Approach/Sources/StringsLibrary/en.lproj/Localizable.strings
+++ b/ios/Approach/Sources/StringsLibrary/en.lproj/Localizable.strings
@@ -214,6 +214,11 @@
 "game.editor.fields.gear.help" = "Choose any additional gear you're using this game";
 "game.editor.fields.alley.lanes.selectLanes" = "Set specific lanes?";
 "game.editor.fields.alley.lanes.manageLanes" = "Manage lanes";
+"game.editor.fields.alley.lanes.duplicate.title" = "Copy lanes to all games?";
+"game.editor.fields.alley.lanes.duplicate.message" = "If you're bowling all your games on the same lanes tonight, easily copy the lanes you just set to the rest of the games. You can change these later.";
+"game.editor.fields.alley.lanes.duplicate.copyToAll" = "Yes, copy to all";
+"game.editor.fields.alley.lanes.duplicate.dismiss" = "No, I might change lanes";
+
 "game.editor.picker.switch" = "Switch game";
 "game.editor.preferences.title" = "Preferences";
 "game.editor.preferences.flashEditorChanges" = "Flash editor changes?";


### PR DESCRIPTION
Fixes #277 

Displays a prompt once when setting the lanes for the first game in a series, asking user if they want to copy those lanes to all of their games.

Required refactoring `GamesEditor.Destination` into `GamesEditor.SheetsDestination` and using a `SwitchStore` for the sheet destinations as the compiler could not handle all the sheets modifiers + the new alert modifier