### PR TITLE
Introducing edit buttons to the tops of lists

### DIFF
--- a/ios/Approach/Package.swift
+++ b/ios/Approach/Package.swift
@@ -369,6 +369,7 @@ let package = Package(
 			dependencies: [
 				"GamesEditorFeature",
 				"ResourceListLibrary",
+				"SeriesEditorFeature",
 			]
 		),
 		.testTarget(
@@ -571,7 +572,6 @@ let package = Package(
 			name: "SeriesListFeature",
 			dependencies: [
 				"GamesListFeature",
-				"SeriesEditorFeature",
 				"SortOrderLibrary",
 			]
 		),

--- a/ios/Approach/Package.swift
+++ b/ios/Approach/Package.swift
@@ -472,7 +472,6 @@ let package = Package(
 		.target(
 			name: "LeaguesListFeature",
 			dependencies: [
-				"LeagueEditorFeature",
 				"SeriesListFeature",
 				"StatisticsWidgetsLayoutFeature",
 			]
@@ -572,6 +571,7 @@ let package = Package(
 			name: "SeriesListFeature",
 			dependencies: [
 				"GamesListFeature",
+				"LeagueEditorFeature",
 				"SortOrderLibrary",
 			]
 		),

--- a/ios/Approach/Package.swift.toml
+++ b/ios/Approach/Package.swift.toml
@@ -89,7 +89,7 @@ services = [ "Analytics", "FeatureFlags" ]
 libraries = [ "ModelsViews", "PickableModels" ]
 
 [features.LeaguesList]
-features = [ "LeagueEditor", "SeriesList", "StatisticsWidgetsLayout" ]
+features = [ "SeriesList", "StatisticsWidgetsLayout" ]
 
 [features.OpponentDetails]
 features = [ "BowlerEditor" ]
@@ -116,7 +116,7 @@ services = [ "Analytics", "FeatureFlags" ]
 libraries = [ "DateTime", "ModelsViews", "PickableModels" ]
 
 [features.SeriesList]
-features = [ "GamesList" ]
+features = [ "GamesList", "LeagueEditor" ]
 libraries = [ "SortOrder" ]
 
 [features.Settings]

--- a/ios/Approach/Package.swift.toml
+++ b/ios/Approach/Package.swift.toml
@@ -61,7 +61,7 @@ services = [ "Analytics", "Avatar", "FeatureFlags", "Preference", "RecentlyUsed"
 libraries = [ "PickableModels" ]
 
 [features.GamesList]
-features = [ "GamesEditor" ]
+features = [ "GamesEditor", "SeriesEditor" ]
 libraries = [ "ResourceList" ]
 
 [features.GearEditor]
@@ -116,7 +116,7 @@ services = [ "Analytics", "FeatureFlags" ]
 libraries = [ "DateTime", "ModelsViews", "PickableModels" ]
 
 [features.SeriesList]
-features = [ "GamesList", "SeriesEditor" ]
+features = [ "GamesList" ]
 libraries = [ "SortOrder" ]
 
 [features.Settings]

--- a/ios/Approach/Sources/GamesListFeature/GamesListView.swift
+++ b/ios/Approach/Sources/GamesListFeature/GamesListView.swift
@@ -6,6 +6,7 @@ import FeatureActionLibrary
 import GamesEditorFeature
 import ModelsLibrary
 import ResourceListLibrary
+import SeriesEditorFeature
 import SharingFeature
 import StringsLibrary
 import SwiftUI
@@ -44,6 +45,10 @@ public struct GamesListView: View {
 				GamesListHeaderView(scores: viewStore.scores)
 			}
 			.toolbar {
+				ToolbarItem(placement: .navigationBarTrailing) {
+					EditButton { viewStore.send(.didTapEditButton) }
+				}
+
 				if viewStore.isSeriesSharingEnabled {
 					ToolbarItem(placement: .navigationBarTrailing) {
 						Button { viewStore.send(.didTapShareButton) } label: {
@@ -66,10 +71,19 @@ public struct GamesListView: View {
 		}
 		.navigationDestination(
 			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GamesList.Destination.State.editor,
-			action: GamesList.Destination.Action.editor
+			state: /GamesList.Destination.State.gameEditor,
+			action: GamesList.Destination.Action.gameEditor
 		) { store in
 			GamesEditorView(store: store)
+		}
+		.sheet(
+			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
+			state: /GamesList.Destination.State.seriesEditor,
+			action: GamesList.Destination.Action.seriesEditor
+		) { store in
+			NavigationStack {
+				SeriesEditorView(store: store)
+			}
 		}
 	}
 }

--- a/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
+++ b/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
@@ -88,7 +88,11 @@ public struct LeagueEditor: Reducer {
 			case didTapAlley
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {}
+		public enum DelegateAction: Equatable {
+			case didFinishCreating(League.Create)
+			case didFinishUpdating(League.Edit)
+			case didFinishDeleting(League.Edit)
+		}
 		public enum InternalAction: Equatable {
 			case setLocationSection(isShown: Bool)
 			case form(LeagueForm.Action)
@@ -174,7 +178,25 @@ public struct LeagueEditor: Reducer {
 						return state._form.didFinishDeleting(result)
 							.map { .internal(.form($0)) }
 
-					case .didFinishCreating, .didFinishUpdating, .didFinishDeleting, .didDiscard:
+					case let  .didFinishDeleting(league):
+						return .concatenate(
+							.send(.delegate(.didFinishDeleting(league))),
+							.run { _ in await dismiss() }
+						)
+
+					case let  .didFinishUpdating(league):
+						return .concatenate(
+							.send(.delegate(.didFinishUpdating(league))),
+							.run { _ in await dismiss() }
+						)
+
+					case let  .didFinishCreating(league):
+						return .concatenate(
+							.send(.delegate(.didFinishCreating(league))),
+							.run { _ in await dismiss() }
+						)
+
+					case .didDiscard:
 						return .run { _ in await dismiss() }
 					}
 

--- a/ios/Approach/Sources/LeaguesListFeature/LeaguesList.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/LeaguesList.swift
@@ -294,7 +294,7 @@ public struct LeaguesList: Reducer {
 
 				case let .destination(.presented(.editor(.delegate(delegateAction)))):
 					switch delegateAction {
-					case .never:
+					case .didFinishCreating, .didFinishDeleting, .didFinishUpdating:
 						return .none
 					}
 

--- a/ios/Approach/Sources/LeaguesRepositoryInterface/Models/League+Edit.swift
+++ b/ios/Approach/Sources/LeaguesRepositoryInterface/Models/League+Edit.swift
@@ -11,5 +11,15 @@ extension League {
 		public var additionalGames: Int?
 		public var excludeFromStatistics: ExcludeFromStatistics
 		public var location: Alley.Summary?
+
+		public var asSeriesHost: SeriesHost {
+			.init(
+				id: id,
+				name: name,
+				numberOfGames: numberOfGames,
+				alley: location,
+				excludeFromStatistics: excludeFromStatistics
+			)
+		}
 	}
 }

--- a/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
@@ -68,6 +68,8 @@ public struct SeriesEditor: Reducer {
 		}
 		public enum DelegateAction: Equatable {
 			case didFinishCreating(Series.Create)
+			case didFinishDeleting(Series.Edit)
+			case didFinishUpdating(Series.Edit)
 		}
 		public enum InternalAction: Equatable {
 			case form(SeriesForm.Action)
@@ -167,7 +169,19 @@ public struct SeriesEditor: Reducer {
 							.run { _ in await dismiss() }
 						)
 
-					case .didFinishUpdating, .didFinishDeleting, .didDiscard:
+					case let .didFinishDeleting(series):
+						return .concatenate(
+							.send(.delegate(.didFinishDeleting(series))),
+							.run { _ in await dismiss() }
+						)
+
+					case let .didFinishUpdating(series):
+						return .concatenate(
+							.send(.delegate(.didFinishUpdating(series))),
+							.run { _ in await dismiss() }
+						)
+
+					case .didDiscard:
 						return .run { _ in await dismiss() }
 					}
 

--- a/ios/Approach/Sources/SeriesListFeature/SeriesList.swift
+++ b/ios/Approach/Sources/SeriesListFeature/SeriesList.swift
@@ -134,7 +134,7 @@ public struct SeriesList: Reducer {
 
 				case let .didTapSeries(id):
 					if let series = state.series[id: id] {
-						state.destination = .games(.init(series: series.asSummary))
+						state.destination = .games(.init(series: series.asSummary, host: state.league))
 					}
 					return .none
 
@@ -179,7 +179,7 @@ public struct SeriesList: Reducer {
 					if let seriesToNavigate = state.seriesToNavigate {
 						if let destination = state.series[id: seriesToNavigate] {
 							state.seriesToNavigate = nil
-							state.destination = .games(.init(series: destination.asSummary))
+							state.destination = .games(.init(series: destination.asSummary, host: state.league))
 						} else {
 							return .send(.internal(.didLoadEditableSeries(.failure(SeriesListError.seriesNotFound(seriesToNavigate)))))
 						}
@@ -212,10 +212,13 @@ public struct SeriesList: Reducer {
 					switch delegateAction {
 					case let .didFinishCreating(created):
 						if let series = state.series[id: created.id] {
-							state.destination = .games(.init(series: series.asSummary))
+							state.destination = .games(.init(series: series.asSummary, host: state.league))
 						} else {
 							state.seriesToNavigate = created.id
 						}
+						return .none
+
+					case .didFinishDeleting, .didFinishUpdating:
 						return .none
 					}
 

--- a/ios/Approach/Sources/SeriesListFeature/SeriesListView.swift
+++ b/ios/Approach/Sources/SeriesListFeature/SeriesListView.swift
@@ -3,6 +3,7 @@ import ComposableArchitecture
 import DateTimeLibrary
 import ErrorsFeature
 import GamesListFeature
+import LeagueEditorFeature
 import ModelsLibrary
 import SeriesEditorFeature
 import SortOrderLibrary
@@ -83,6 +84,10 @@ public struct SeriesListView: View {
 			.navigationTitle(viewStore.leagueName)
 			.toolbar {
 				ToolbarItem(placement: .navigationBarTrailing) {
+					EditButton { viewStore.send(.didTapEditButton) }
+				}
+
+				ToolbarItem(placement: .navigationBarTrailing) {
 					AddButton { viewStore.send(.didTapAddButton) }
 				}
 
@@ -100,11 +105,20 @@ public struct SeriesListView: View {
 		)
 		.sheet(
 			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /SeriesList.Destination.State.editor,
-			action: SeriesList.Destination.Action.editor
+			state: /SeriesList.Destination.State.seriesEditor,
+			action: SeriesList.Destination.Action.seriesEditor
 		) { store in
 			NavigationStack {
 				SeriesEditorView(store: store)
+			}
+		}
+		.sheet(
+			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
+			state: /SeriesList.Destination.State.leagueEditor,
+			action: SeriesList.Destination.Action.leagueEditor
+		) { store in
+			NavigationStack {
+				LeagueEditorView(store: store)
 			}
 		}
 		.sheet(

--- a/ios/Approach/Sources/SeriesRepositoryInterface/Models/Series+Edit.swift
+++ b/ios/Approach/Sources/SeriesRepositoryInterface/Models/Series+Edit.swift
@@ -12,5 +12,9 @@ extension Series {
 		public var preBowl: PreBowl
 		public var excludeFromStatistics: ExcludeFromStatistics
 		public var location: Alley.Summary?
+
+		public var asSummary: Summary {
+			.init(id: id, date: date)
+		}
 	}
 }


### PR DESCRIPTION
Part #282 

Improves discoverability of editing by adding a prominent "Edit" button to the tops of many list details. Still more work to be done here (Gear List and Alleys List) but this is a good start.

When gear details and alley details are launched will be a good time to include edit buttons for those properties