### PR TITLE
Fix: Pins no longer pop back up after swiping

### DIFF
--- a/ios/Approach/Sources/ExtensionsLibrary/Array+Extensions.swift
+++ b/ios/Approach/Sources/ExtensionsLibrary/Array+Extensions.swift
@@ -8,4 +8,12 @@ extension Set {
 			insert(element)
 		}
 	}
+
+	public mutating func toggle(_ element: Element, toContain: Bool) {
+		if toContain {
+			insert(element)
+		} else {
+			remove(element)
+		}
+	}
 }

--- a/ios/Approach/Sources/FramesRepositoryInterface/Models/Frame+Edit.swift
+++ b/ios/Approach/Sources/FramesRepositoryInterface/Models/Frame+Edit.swift
@@ -96,6 +96,14 @@ extension Frame.Edit {
 		}
 	}
 
+	public mutating func setDownedPins(rollIndex: Int, to downedPins: Set<Pin>) {
+		guaranteeRollExists(upTo: rollIndex)
+		rolls[rollIndex].roll.pinsDowned = downedPins
+		for roll in (rollIndex + 1..<rolls.endIndex) {
+			rolls[roll].roll.pinsDowned.subtract(downedPins)
+		}
+	}
+
 	public mutating func guaranteeRollExists(upTo index: Int) {
 		while rolls.count < index + 1 {
 			rolls.append(.init(index: rolls.count, roll: .default, bowlingBall: nil))

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+FrameEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+FrameEditor.swift
@@ -1,20 +1,28 @@
 import ComposableArchitecture
+import ModelsLibrary
 
 extension GamesEditor.State {
 	var frameEditor: FrameEditor.State? {
 		get {
 			guard let _frameEditor, let frames else { return nil }
+			let frame = frames[currentFrameIndex]
 			var frameEditor = _frameEditor
 			frameEditor.isEditable = isEditable
-			frameEditor.currentRollIndex = currentRollIndex
-			frameEditor.frame = frames[currentFrameIndex]
+			frameEditor.downedPins = frame.deck(forRoll: currentRollIndex)
+			let pinsDownLastFrame = currentRollIndex > 0 ? frame.deck(forRoll: currentRollIndex - 1) : []
+			if Frame.isLast(frame.index) {
+				frameEditor.lockedPins = pinsDownLastFrame.arePinsCleared ? [] : pinsDownLastFrame
+			} else {
+				frameEditor.lockedPins = pinsDownLastFrame
+			}
 			return frameEditor
 		}
 		set {
 			_frameEditor = newValue
 			guard let newValue else { return }
 			let currentFrameIndex = self.currentFrameIndex
-			self.frames?[currentFrameIndex] = newValue.frame
+			let currentRollIndex = self.currentRollIndex
+			self.frames?[currentFrameIndex].setDownedPins(rollIndex: currentRollIndex, to: newValue.downedPins)
 			self.setCurrent()
 		}
 	}

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+FrameEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+FrameEditor.swift
@@ -8,13 +8,13 @@ extension GamesEditor.State {
 			let frame = frames[currentFrameIndex]
 			var frameEditor = _frameEditor
 			frameEditor.isEditable = isEditable
-			frameEditor.downedPins = frame.deck(forRoll: currentRollIndex)
 			let pinsDownLastFrame = currentRollIndex > 0 ? frame.deck(forRoll: currentRollIndex - 1) : []
 			if Frame.isLast(frame.index) {
 				frameEditor.lockedPins = pinsDownLastFrame.arePinsCleared ? [] : pinsDownLastFrame
 			} else {
 				frameEditor.lockedPins = pinsDownLastFrame
 			}
+			frameEditor.downedPins = frame.deck(forRoll: currentRollIndex).subtracting(frameEditor.lockedPins)
 			return frameEditor
 		}
 		set {

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
@@ -270,10 +270,7 @@ public struct GamesEditor: Reducer {
 					state.hideNextHeaderIfNecessary(updatingRollIndexTo: newRollIndex, frameIndex: newFrameIndex ?? 0)
 
 					state.frames![state.currentFrameIndex].guaranteeRollExists(upTo: state.currentRollIndex)
-					state._frameEditor = .init(
-						currentRollIndex: state.currentRollIndex,
-						frame: state.frames![state.currentFrameIndex]
-					)
+					state._frameEditor = .init()
 
 					state._rollEditor = .init(
 						ballRolled: state.frames![state.currentFrameIndex].rolls[state.currentRollIndex].bowlingBall,

--- a/ios/Previews/GameEditorPreview/GameEditorPreviewApp.swift
+++ b/ios/Previews/GameEditorPreview/GameEditorPreviewApp.swift
@@ -20,7 +20,8 @@ public struct GameEditorPreviewApp: App {
 				initialGameId: UUID(1)
 			),
 			reducer: {
-				GamesEditor()//._printChanges()
+				GamesEditor()
+					._printChanges()
 					.dependency(\.database, {
 						let db: any DatabaseWriter
 						do {


### PR DESCRIPTION
Fixes #275 

Refactored `FrameEditor` to be overall more efficient, using less comparisons and sending less actions into the store. The view now tracks which pins are "swipeable" in that they haven't been swiped in the current interaction, then only sends updates for the first time those pins are interacted with. Instead of hundreds of actions from a single swipe, we now see a maximum of 5.

The FrameEditor also better manages when it sends a save action, only after a swipe, and only if there were meaningful changes. Again, instead of sending the action hundreds of times.

Also fixes the tap gesture on pins so it's easier to tap singular pins. 

Tested on a real device so should better reflect the actual state of things.