### PR TITLE
Fix score calculation when tapping to skip over frame

### DIFF
--- a/ios/Approach/Sources/DatabaseLibrary/Migrations/DBMigration.swift
+++ b/ios/Approach/Sources/DatabaseLibrary/Migrations/DBMigration.swift
@@ -38,6 +38,7 @@ extension DatabaseMigrator {
 		registerMigration(Migration20230918OnDeleteGearBowlerSetNull.self)
 		registerMigration(Migration20230918MigrateStatisticsWidgetType.self)
 		registerMigration(Migration20230920ValidateGameScores.self)
+		registerMigration(Migration20231002ValidateGameScores.self)
 	}
 
 	mutating func registerMigration(_ migration: DBMigration.Type) {

--- a/ios/Approach/Sources/DatabaseLibrary/Migrations/Migration20231002ValidateGameScores.swift
+++ b/ios/Approach/Sources/DatabaseLibrary/Migrations/Migration20231002ValidateGameScores.swift
@@ -3,7 +3,7 @@ import GRDB
 import ScoreKeeperLibrary
 import ScoreKeeperModelsLibrary
 
-struct Migration20230920ValidateGameScores: DBMigration {
+struct Migration20231002ValidateGameScores: DBMigration {
 	static func migrate(_ db: Database) throws {
 		let games = try Game
 			.all()
@@ -29,7 +29,7 @@ struct Migration20230920ValidateGameScores: DBMigration {
 	}
 }
 
-extension Migration20230920ValidateGameScores {
+extension Migration20231002ValidateGameScores {
 	struct Game: Decodable, TableRecord, FetchableRecord {
 		static let databaseTableName = "game"
 		let id: UUID

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Utilities.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Utilities.swift
@@ -90,7 +90,7 @@ extension GamesEditor.State {
 		case .duplicateLanesAlert, .sheets, .none:
 			break
 		}
-}
+	}
 
 	mutating func hideNextHeaderIfNecessary(
 		updatingRollIndexTo: Int? = nil,
@@ -98,5 +98,15 @@ extension GamesEditor.State {
 	) {
 		forceNextHeaderElementNil = game?.scoringMethod == .manual || frames?.first(where: { $0.hasUntouchedRoll }) == nil
 		setCurrent(rollIndex: updatingRollIndexTo, frameIndex: frameIndex)
+	}
+
+	mutating func populateFrames(upTo: Int) {
+		for frameIndex in 0..<upTo {
+			guard let rollsCount = frames?[frameIndex].rolls.count, rollsCount < Frame.NUMBER_OF_ROLLS else { continue }
+			let lastRollIndex = rollsCount - 1
+			if frames?[frameIndex].deck(forRoll: lastRollIndex).arePinsCleared == false {
+				frames?[frameIndex].guaranteeRollExists(upTo: Frame.NUMBER_OF_ROLLS - 1)
+			}
+		}
 	}
 }

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
@@ -172,8 +172,9 @@ public struct GamesEditor: Reducer {
 			state.setCurrent(rollIndex: state.currentFrame.rollIndex, frameIndex: state.currentFrame.frameIndex)
 			let currentFrameIndex = state.currentFrameIndex
 			let currentRollIndex = state.currentRollIndex
+			state.populateFrames(upTo: currentFrameIndex)
 			state.frames?[currentFrameIndex].guaranteeRollExists(upTo: currentRollIndex)
-			return .none
+			return save(frame: state.frames?[currentFrameIndex])
 		}
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {

--- a/ios/Approach/Tests/DatabaseLibraryTests/DBMigrationTests.swift
+++ b/ios/Approach/Tests/DatabaseLibraryTests/DBMigrationTests.swift
@@ -27,6 +27,7 @@ final class DBMigrationTests: XCTestCase {
 		"Migration20230918OnDeleteGearBowlerSetNull",
 		"Migration20230918MigrateStatisticsWidgetType",
 		"Migration20230920ValidateGameScores",
+		"Migration20231002ValidateGameScores",
 	]
 
 	func testIdentifier() {


### PR DESCRIPTION
Fixes #300

Ensure that empty frames are recognized and missing roles are accounted for and we don't simply use the next available roll to fill in scores for strikes. Fixes an issue where a strike followed by a frame A with 1 ball and another frame B with 1 ball (implying A has 2 empty rolls) instead calculates the strike value using the ball 1 from frame A and ball 1 from frame B.

Additionally, revalidates scores with a migration to ensure they're all calculated using the latest scoring.