### PR TITLE
Fix: Score calculations are no longer applied to incorrect game

### DIFF
--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GameDetails.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+GameDetails.swift
@@ -10,6 +10,7 @@ extension GamesEditor {
 		case let .delegate(delegateAction):
 			switch delegateAction {
 			case let .didEditMatchPlay(.success(matchPlay)):
+				guard state.game?.matchPlay == nil || state.game?.matchPlay?.id == matchPlay?.id else { return .none }
 				state.game?.matchPlay = matchPlay
 				return save(matchPlay: state.game?.matchPlay)
 
@@ -19,7 +20,7 @@ extension GamesEditor {
 					.map { .internal(.errors($0)) }
 
 			case let .didEditGame(game):
-				guard let game else { return .none }
+				guard let game, state.currentGameId == game.id else { return .none }
 				state.game = game
 				state.hideNextHeaderIfNecessary()
 				return save(game: state.game)


### PR DESCRIPTION
Fixes #346 

When getting a score update we pass along the game ID that update is for and ensure the correct game is loaded before applying the score.

Aside, we do the same for the match play now as well when updating.

Furthermore, noticed a spot where we weren't fully loading a game if the game details were being updated. We would early exit the function. This has been resolved.