### PR TITLE
Fix: Spareable stats are calculated correctly in the 10th frame

### DIFF
--- a/ios/Approach/Sources/ModelsLibrary/Frame.swift
+++ b/ios/Approach/Sources/ModelsLibrary/Frame.swift
@@ -69,6 +69,11 @@ public protocol InspectableFrame {
 	var pinsLeftOnDeck: Set<Pin> { get }
 }
 
+public struct RollPair: Equatable {
+	public let firstRoll: Frame.OrderedRoll
+	public let secondRoll: Frame.OrderedRoll
+}
+
 extension InspectableFrame {
 	public var firstRolls: [Frame.OrderedRoll] {
 		guard let firstRoll = rolls.first else { return [] }
@@ -111,6 +116,20 @@ extension InspectableFrame {
 			return secondRolls
 		} else {
 			return [secondRoll]
+		}
+	}
+
+	public var rollPairs: [RollPair] {
+		let firstRolls = self.firstRolls
+		let secondRolls = self.secondRolls
+		return secondRolls.compactMap { secondRoll in
+			guard
+				let matchingFirstRoll = firstRolls.first(where: { $0.index == secondRoll.index - 1 }),
+				!matchingFirstRoll.roll.pinsDowned.arePinsCleared
+			else {
+				return nil
+			}
+			return RollPair(firstRoll: matchingFirstRoll, secondRoll: secondRoll)
 		}
 	}
 

--- a/ios/Approach/Sources/StatisticsLibrary/Statistic.swift
+++ b/ios/Approach/Sources/StatisticsLibrary/Statistic.swift
@@ -116,8 +116,8 @@ public protocol TrackablePerSecondRoll: TrackablePerFrame {
 
 extension TrackablePerSecondRoll {
 	public mutating func adjust(byFrame: Frame.TrackableEntry, configuration: TrackablePerFrameConfiguration) {
-		for (firstRoll, secondRoll) in zip(byFrame.firstRolls, byFrame.secondRolls) {
-			adjust(bySecondRoll: secondRoll, afterFirstRoll: firstRoll, configuration: configuration)
+		for rollPair in byFrame.rollPairs {
+			adjust(bySecondRoll: rollPair.secondRoll, afterFirstRoll: rollPair.firstRoll, configuration: configuration)
 		}
 	}
 }

--- a/ios/Approach/Tests/ModelsLibraryTests/FrameTests.swift
+++ b/ios/Approach/Tests/ModelsLibraryTests/FrameTests.swift
@@ -116,6 +116,23 @@ final class FrameTests: XCTestCase {
 		])
 	}
 
+	func testFirstRolls_InLastFrame_WithThreeStrikes_ReturnsThreeRolls() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(frame.firstRolls, [
+			.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+			.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+			.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+		])
+	}
+
 	// MARK: - Second Rolls
 
 	func testSecondRolls_InAnyFrame_ReturnsSecondRoll() {
@@ -214,6 +231,162 @@ final class FrameTests: XCTestCase {
 		)
 
 		XCTAssertEqual(frame.secondRolls, [])
+	}
+
+	func testSecondRolls_InLastFrame_WithThreeStrikes_ReturnsNoRolls() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(frame.secondRolls, [])
+	}
+
+	// MARK: - Roll Pairs
+
+	func testRollPairs_InAnyFrame_ReturnsPairs() {
+		let frame1 = Frame.Summary(
+			index: 0,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.headPin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(
+			frame1.rollPairs,
+			[
+				.init(
+					firstRoll: .init(index: 0, roll: .init(pinsDowned: [.headPin])),
+					secondRoll: .init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin]))
+				)
+			]
+		)
+
+		let frame2 = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.headPin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(
+			frame2.rollPairs,
+			[
+				.init(
+					firstRoll: .init(index: 0, roll: .init(pinsDowned: [.headPin])),
+					secondRoll: .init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin]))
+				)
+			]
+		)
+	}
+
+	func testRollPairs_WithNoRolls_ReturnsNothing() {
+		let frame = Frame.Summary(index: 0, rolls: [])
+
+		XCTAssertEqual(frame.rollPairs, [])
+	}
+
+	func testRollPairs_WithNoSecondRolls_ReturnsNothing() {
+		let frame = Frame.Summary(index: 0, rolls: [.init(index: 0, roll: .default)])
+
+		XCTAssertEqual(frame.rollPairs, [])
+	}
+
+	func testRollPairs_InLastFrame_WithNoStrikesOrSpares_ReturnsOnePair() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(
+			frame.rollPairs,
+			[
+				.init(
+					firstRoll: .init(index: 0, roll: .init(pinsDowned: [])),
+					secondRoll: .init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin]))
+				),
+			]
+		)
+	}
+
+	func testRollPairs_InLastFrame_WithOneStrike_ReturnsOnePair() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(
+			frame.rollPairs,
+			[
+				.init(
+					firstRoll: .init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+					secondRoll: .init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin]))
+				),
+			]
+		)
+	}
+
+	func testRollPairs_InLastFrame_WithOneSpare_ReturnsOnePair() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(
+			frame.rollPairs,
+			[
+				.init(
+					firstRoll: .init(index: 0, roll: .init(pinsDowned: [.headPin, .rightTwoPin, .rightThreePin])),
+					secondRoll: .init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin]))
+				),
+			]
+		)
+	}
+
+	func testRollPairs_InLastFrame_WithTwoStrikes_ReturnsNoPairs() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(frame.rollPairs, [])
+	}
+
+	func testRollPairs_InLastFrame_WithThreeStrikes_ReturnsNoPairs() {
+		let frame = Frame.Summary(
+			index: Game.NUMBER_OF_FRAMES - 1,
+			rolls: [
+				.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+				.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin, .rightThreePin])),
+			]
+		)
+
+		XCTAssertEqual(frame.rollPairs, [])
 	}
 
 	// MARK: - Pins Left On Deck

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+AcesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+AcesSparedTests.swift
@@ -62,6 +62,79 @@ final class AcesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithAcesSpared_Adjusts() {
+		let statistic = create(
+			statistic: Statistics.AcesSpared.self,
+			adjustedByFrames: [
+				// Open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin])),
+						.init(index: 1, roll: .init(pinsDowned: [.rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+					]
+				),
+				// Spared attempt, followed by strike
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+				// Spared attempt, followed by open
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Strike, followed by spared attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .rightTwoPin])),
+					]
+				),
+				// Strike followed by open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Two strikes, followed by spareable shot
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin])),
+					]
+				),
+				// Three strikes
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+			]
+		)
+
+		AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+	}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.AcesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+ChopOffsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+ChopOffsSparedTests.swift
@@ -96,6 +96,79 @@ final class ChopOffsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 2, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithChopOffsSpared_Adjusts() {
+		let statistic = create(
+			statistic: Statistics.ChopOffsSpared.self,
+			adjustedByFrames: [
+				// Open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+					]
+				),
+				// Spared attempt, followed by strike
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+				// Spared attempt, followed by open
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Strike, followed by spared attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .leftTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+					]
+				),
+				// Strike followed by open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Two strikes, followed by spareable shot
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+				// Three strikes
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+			]
+		)
+
+		AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+	}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.ChopOffsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+FivesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+FivesSparedTests.swift
@@ -96,6 +96,79 @@ final class FivesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 2, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithFivesSpared_Adjusts() {
+		let statistic = create(
+			statistic: Statistics.FivesSpared.self,
+			adjustedByFrames: [
+				// Open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.headPin, .leftThreePin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+					]
+				),
+				// Spared attempt, followed by strike
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+				// Spared attempt, followed by open
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Strike, followed by spared attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+					]
+				),
+				// Strike followed by open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Two strikes, followed by spareable shot
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+					]
+				),
+				// Three strikes
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+			]
+		)
+
+		AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+	}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.FivesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+HeadPinsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+HeadPinsSparedTests.swift
@@ -105,6 +105,80 @@ final class HeadPinsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithHeadPinsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.HeadPinsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin, .rightTwoPin, .rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.headPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				],
+				withFrameConfiguration: .init(countHeadPin2AsHeadPin: true, countSplitWithBonusAsSplit: false)
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.HeadPinsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftChopOffsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftChopOffsSparedTests.swift
@@ -96,6 +96,79 @@ final class LeftChopOffsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithLeftChopsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.LeftChopOffsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.LeftChopOffsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftFivesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftFivesSparedTests.swift
@@ -96,6 +96,79 @@ final class LeftFivesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithLeftFivesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.LeftFivesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .leftTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .leftTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .leftTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.headPin, .rightTwoPin, .rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.LeftFivesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftSplitsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftSplitsSparedTests.swift
@@ -207,6 +207,80 @@ final class LeftSplitsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithLeftSplitsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.LeftSplitsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				],
+				withFrameConfiguration: .init(countHeadPin2AsHeadPin: false, countSplitWithBonusAsSplit: true)
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.LeftSplitsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftTapsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftTapsSparedTests.swift
@@ -56,6 +56,79 @@ final class LeftTapsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 2, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithLeftTapsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.LeftTapsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.LeftTapsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftThreesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftThreesSparedTests.swift
@@ -96,6 +96,79 @@ final class LeftThreesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithLeftThreesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.LeftThreesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightThreePin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightTwoPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightTwoPin, .rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.LeftThreesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftTwelvesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+LeftTwelvesSparedTests.swift
@@ -112,6 +112,79 @@ final class LeftTwelvesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 3, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithLeftTwelvesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.LeftTwelvesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightThreePin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.LeftTwelvesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightChopOffsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightChopOffsSparedTests.swift
@@ -96,6 +96,79 @@ final class RightChopOffsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithRightChopsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.RightChopOffsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.RightChopOffsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightFivesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightFivesSparedTests.swift
@@ -96,6 +96,79 @@ final class RightFivesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithRightFivesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.RightFivesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.RightFivesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightSplitsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightSplitsSparedTests.swift
@@ -110,6 +110,80 @@ final class RightSplitsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 2, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithRightSplitsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.RightSplitsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.headPin, .rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightThreePin, .leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin, .rightTwoPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightThreePin, .leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.headPin, .rightThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				],
+				withFrameConfiguration: .init(countHeadPin2AsHeadPin: false, countSplitWithBonusAsSplit: true)
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.RightSplitsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightTapsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightTapsSparedTests.swift
@@ -56,6 +56,79 @@ final class RightTapsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 2, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithRightTapsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.RightTapsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.RightTapsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightThreesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightThreesSparedTests.swift
@@ -96,6 +96,79 @@ final class RightThreesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithRightThreesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.RightThreesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightTwoPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.RightThreesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightTwelvesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+RightTwelvesSparedTests.swift
@@ -112,6 +112,79 @@ final class RightTwelvesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 3, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithRightTwelvesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.RightTwelvesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.RightTwelvesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+SplitsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+SplitsSparedTests.swift
@@ -186,6 +186,80 @@ final class SplitsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithSplitsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.SplitsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin, .headPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin, .headPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				],
+				withFrameConfiguration: .init(countHeadPin2AsHeadPin: false, countSplitWithBonusAsSplit: true)
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.SplitsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+TapsSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+TapsSparedTests.swift
@@ -86,6 +86,79 @@ final class TapsSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 4, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithTapsSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.TapsSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightTwoPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.TapsSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+ThreesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+ThreesSparedTests.swift
@@ -96,6 +96,79 @@ final class ThreesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 2, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithThreesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.ThreesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .leftThreePin, .rightTwoPin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.rightThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.ThreesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+TwelvesSparedTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/FirstRoll/Statistics+TwelvesSparedTests.swift
@@ -98,6 +98,79 @@ final class TwelvesSparedTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 4, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithTwelvesSpared_Adjusts() {
+			let statistic = create(
+				statistic: Statistics.TwelvesSpared.self,
+				adjustedByFrames: [
+					// Open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftThreePin])),
+						]
+					),
+					// Spared attempt, followed by strike
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+					// Spared attempt, followed by open
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftThreePin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Strike, followed by spared attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .leftThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.rightThreePin])),
+						]
+					),
+					// Strike followed by open attempt
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .leftThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [])),
+						]
+					),
+					// Two strikes, followed by spareable shot
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .headPin, .leftThreePin, .rightTwoPin])),
+						]
+					),
+					// Three strikes
+					Frame.TrackableEntry(
+						index: Game.NUMBER_OF_FRAMES - 1,
+						rolls: [
+							.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+							.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						]
+					),
+				]
+			)
+
+			AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+		}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.TwelvesSpared.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")

--- a/ios/Approach/Tests/StatisticsLibraryTests/Trackable/Overall/Statistics+SpareConversionsTests.swift
+++ b/ios/Approach/Tests/StatisticsLibraryTests/Trackable/Overall/Statistics+SpareConversionsTests.swift
@@ -85,6 +85,79 @@ final class SpareConversionsTests: XCTestCase {
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 1, formattedAs: "0%", overridingIsEmptyExpectation: true)
 	}
 
+	func testAdjust_InLastFrame_ByFramesWithSpare_Adjusts() {
+		let statistic = create(
+			statistic: Statistics.SpareConversions.self,
+			adjustedByFrames: [
+				// Open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+					]
+				),
+				// Spared attempt, followed by strike
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+				// Spared attempt, followed by open
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Strike, followed by spared attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+					]
+				),
+				// Strike followed by open attempt
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [])),
+					]
+				),
+				// Two strikes, followed by spareable shot
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin])),
+					]
+				),
+				// Three strikes
+				Frame.TrackableEntry(
+					index: Game.NUMBER_OF_FRAMES - 1,
+					rolls: [
+						.init(index: 0, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 1, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+						.init(index: 2, roll: .init(pinsDowned: [.leftTwoPin, .leftThreePin, .headPin, .rightThreePin, .rightTwoPin])),
+					]
+				),
+			]
+		)
+
+		AssertPercentage(statistic, hasNumerator: 3, withDenominator: 5, formattedAs: "60% (3)")
+	}
+
 	func testAdjustBySeries_DoesNothing() {
 		let statistic = create(statistic: Statistics.SpareConversions.self, adjustedBySeries: Series.TrackableEntry.mocks)
 		AssertPercentage(statistic, hasNumerator: 0, withDenominator: 0, formattedAs: "0%")


### PR DESCRIPTION
Fixes #359 

Instead of `zip`ing `firstRolls` and `secondRolls`, which lead to strike balls being zipped with the follow-up shot, we instead find appropriate pairs of rolls by getting the `secondRolls` and searching for the matching `firstRoll`, if available.

This ensures each secondRoll is paired with an appropriate `firstRoll` and never a strike frame, so stats based on pinfall can be calculated correctly.

Additionally adds test coverage in all `TrackablePerSecondRoll` statistics to ensure correctness