### PR TITLE
Fix: Do not show next game button automatically after strike in 10th

### DIFF
--- a/ios/Approach/Sources/FramesRepositoryInterface/Models/Frame+Edit.swift
+++ b/ios/Approach/Sources/FramesRepositoryInterface/Models/Frame+Edit.swift
@@ -73,7 +73,11 @@ extension Frame.Edit {
 
 	public var firstUntouchedRoll: Int? {
 		guard rolls.count < Frame.NUMBER_OF_ROLLS else { return nil }
-		return deck(forRoll: rolls.endIndex - 1).arePinsCleared ? nil : rolls.endIndex
+		if Frame.isLast(index) {
+			return rolls.endIndex
+		} else {
+			return deck(forRoll: rolls.endIndex - 1).arePinsCleared ? nil : rolls.endIndex
+		}
 	}
 
 	public mutating func setBowlingBall(_ bowlingBall: Gear.Summary?, forRoll rollIndex: Int) {


### PR DESCRIPTION
Fixes #367 

Issue was not with closing the phone (which is why I thought it was hard to reproduce), but had to do with marking a strike or spare in the 10th frame.

Once the pins were cleared once in the 10th frame, `firstUntouchedRoll` would start returning nil, as though there were no more rolls to be recorded. Which would make sense in any frame but the 10th -- in the 10th we always want to record all 3 rolls.

Fix was to ensure `firstUntouchedRoll` always returned the next index in the 10th frame if there weren't already 3 rolls