### PR TITLE
fix(ios): filter empty frames with no rolls from statistics

### DIFF
--- a/ios/Approach/Sources/StatisticsRepository/Extensions/TrackableFilter+Extensions.swift
+++ b/ios/Approach/Sources/StatisticsRepository/Extensions/TrackableFilter+Extensions.swift
@@ -68,6 +68,12 @@ extension TrackableFilter {
 				.annotated(withRequired: Frame.Database.game.select(
 					Game.Database.Columns.index.forKey("gameIndex")
 				))
+				.filter(
+					!(Frame.Database.Columns.roll1 == nil &&
+						Frame.Database.Columns.roll2 == nil &&
+						(Frame.Database.Columns.roll0 == nil || Frame.Database.Columns.roll0 == "000000")
+						)
+				)
 				.asRequest(of: Frame.TrackableEntry.self)
 		)
 	}


### PR DESCRIPTION
Fixes #390 

Prevent these frames from affecting statistics by excluding them from the TrackableFrames query. We don't exclude them in any other case, because we want to make sure we're always loading all 10 frames for a game when possible.

