### PR TITLE
Migrate to swift-composable-architecture 1.4/1.5

### DIFF
--- a/ios/Approach/Sources/AccessoriesOverviewFeature/AccessoriesOverview.swift
+++ b/ios/Approach/Sources/AccessoriesOverviewFeature/AccessoriesOverview.swift
@@ -31,7 +31,7 @@ public struct AccessoriesOverview: Reducer {
 	}
 
 	public enum Action: FeatureAction {
-		public enum ViewAction {
+		@CasePathable public enum ViewAction {
 			case task
 			case onAppear
 			case didTapViewAllAlleys
@@ -41,10 +41,8 @@ public struct AccessoriesOverview: Reducer {
 			case didTapAddGear
 			case didSwipe(SwipeAction, Item)
 		}
-		public enum DelegateAction { case doNothing }
-
-		@CasePathable
-		public enum InternalAction {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case itemsResponse(Result<[Item], Error>)
 			case didFinishDeletingItem(Result<Item, Error>)
 			case didLoadEditableAlley(Result<Alley.EditWithLanes, Error>)
@@ -69,7 +67,7 @@ public struct AccessoriesOverview: Reducer {
 			case alert(AlertState<AlertAction>)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case alleyEditor(AlleyEditor.Action)
 			case alleysList(AlleysList.Action)
 			case gearEditor(GearEditor.Action)
@@ -105,7 +103,7 @@ public struct AccessoriesOverview: Reducer {
 		}
 	}
 
-	public enum SwipeAction: Equatable {
+	public enum SwipeAction {
 		case edit
 	}
 

--- a/ios/Approach/Sources/AddressLookupFeature/AddressLookup.swift
+++ b/ios/Approach/Sources/AddressLookupFeature/AddressLookup.swift
@@ -23,18 +23,18 @@ public struct AddressLookup: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didFirstAppear
 			case didTapCancelButton
 			case didTapResult(AddressLookupResult.ID)
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didReceiveResults(TaskResult<[AddressLookupResult]>)
-			case didLoadAddress(TaskResult<Location.Edit>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didReceiveResults(Result<[AddressLookupResult], Error>)
+			case didLoadAddress(Result<Location.Edit, Error>)
 		}
 
 		case view(ViewAction)
@@ -90,7 +90,7 @@ public struct AddressLookup: Reducer {
 					guard let address = state.results[id: id] else { return .none }
 					state.isLoadingAddress = true
 					return .run { send in
-						await send(.internal(.didLoadAddress(TaskResult {
+						await send(.internal(.didLoadAddress(Result {
 							guard let location = try await addressLookup.lookUpAddress(address) else {
 								throw LookupError.addressNotFound
 							}

--- a/ios/Approach/Sources/AddressLookupFeature/AddressLookup.swift
+++ b/ios/Approach/Sources/AddressLookupFeature/AddressLookup.swift
@@ -59,7 +59,7 @@ public struct AddressLookup: Reducer {
 	@Dependency(\.dismiss) var dismiss
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyEditor.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyEditor.swift
@@ -62,17 +62,17 @@ public struct AlleyEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapAddressField
 			case didTapManageLanes
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didCreateLanes(TaskResult<Alley.Create>)
-			case didUpdateLanes(TaskResult<Alley.Edit>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didCreateLanes(Result<Alley.Create, Error>)
+			case didUpdateLanes(Result<Alley.Edit, Error>)
 			case form(AlleyForm.Action)
 			case addressLookup(PresentationAction<AddressLookup.Action>)
 			case alleyLanesEditor(PresentationAction<AlleyLanesEditor.Action>)

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyEditor.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyEditor.swift
@@ -95,7 +95,7 @@ public struct AlleyEditor: Reducer {
 	@Dependency(\.lanes) var lanes
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
 			AlleyForm()

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyEditor.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyEditor.swift
@@ -97,7 +97,7 @@ public struct AlleyEditor: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
+		Scope(state: \.form, action: \.internal.form) {
 			AlleyForm()
 				.dependency(\.records, .init(
 					create: alleys.create,
@@ -227,10 +227,10 @@ public struct AlleyEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$addressLookup, action: /Action.internal..Action.InternalAction.addressLookup) {
+		.ifLet(\.$addressLookup, action: \.internal.addressLookup) {
 			AddressLookup()
 		}
-		.ifLet(\.$alleyLanesEditor, action: /Action.internal..Action.InternalAction.alleyLanesEditor) {
+		.ifLet(\.$alleyLanesEditor, action: \.internal.alleyLanesEditor) {
 			AlleyLanesEditor()
 		}
 

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyEditorView.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyEditorView.swift
@@ -34,7 +34,7 @@ public struct AlleyEditorView: View {
 
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
-			FormView(store: store.scope(state: \.form, action: /AlleyEditor.Action.InternalAction.form)) {
+			FormView(store: store.scope(state: \.form, action: \.internal.form)) {
 				detailsSection(viewStore)
 				mapSection(viewStore)
 				materialSection(viewStore)
@@ -47,7 +47,7 @@ public struct AlleyEditorView: View {
 			}
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.sheet(store: store.scope(state: \.$addressLookup, action: { .internal(.addressLookup($0)) })) { scopedStore in
+		.sheet(store: store.scope(state: \.$addressLookup, action: \.internal.addressLookup)) { scopedStore in
 			NavigationStack {
 				AddressLookupView(store: scopedStore)
 					.navigationTitle(Strings.Alley.Editor.Fields.Address.editorTitle)
@@ -55,7 +55,7 @@ public struct AlleyEditorView: View {
 			}
 		}
 		.navigationDestination(
-			store: store.scope(state: \.$alleyLanesEditor, action: { .internal(.alleyLanesEditor($0)) })
+			store: store.scope(state: \.$alleyLanesEditor, action: \.internal.alleyLanesEditor)
 		) {
 			AlleyLanesEditorView(store: $0)
 		}

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AddLaneForm/AddLaneForm.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AddLaneForm/AddLaneForm.swift
@@ -31,7 +31,7 @@ public struct AddLaneForm: Reducer {
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AddLaneForm/AddLaneForm.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AddLaneForm/AddLaneForm.swift
@@ -11,16 +11,16 @@ public struct AddLaneForm: Reducer {
 		@BindingState var lanesToAdd = 1
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didTapSaveButton
 			case didTapCancelButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didFinishAddingLanes(Int?)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AlleyLanesEditor.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AlleyLanesEditor.swift
@@ -31,18 +31,18 @@ public struct AlleyLanesEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapAddLaneButton
 			case didTapAddMultipleLanesButton
 			case alert(PresentationAction<AlertAction>)
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 
-		public enum InternalAction: Equatable {
-			case didDeleteLane(TaskResult<Lane.ID>)
+		@CasePathable public enum InternalAction {
+			case didDeleteLane(Result<Lane.ID, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 			case laneEditor(id: LaneEditor.State.ID, action: LaneEditor.Action)
@@ -96,7 +96,7 @@ public struct AlleyLanesEditor: Reducer {
 					switch alertAction {
 					case let .didTapDeleteButton(lane):
 						return .run { send in
-							await send(.internal(.didDeleteLane(TaskResult {
+							await send(.internal(.didDeleteLane(Result {
 								try await lanes.delete([lane])
 								return lane
 							})))

--- a/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AlleyLanesEditorView.swift
+++ b/ios/Approach/Sources/AlleyEditorFeature/AlleyLanesEditor/AlleyLanesEditorView.swift
@@ -33,14 +33,10 @@ public struct AlleyLanesEditorView: View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			List {
 				Section {
-					ForEachStore(
-						store.scope(state: \.existingLaneEditors, action: /AlleyLanesEditor.Action.InternalAction.laneEditor(id:action:))
-					) {
+					ForEachStore(store.scope(state: \.existingLaneEditors, action: \.internal.laneEditor)) {
 						LaneEditorView(store: $0)
 					}
-					ForEachStore(
-						store.scope(state: \.newLaneEditors, action: /AlleyLanesEditor.Action.InternalAction.laneEditor(id:action:))
-					) {
+					ForEachStore(store.scope(state: \.newLaneEditors, action: \.internal.laneEditor)) {
 						LaneEditorView(store: $0)
 					}
 				} footer: {
@@ -60,9 +56,9 @@ public struct AlleyLanesEditorView: View {
 			.navigationTitle(Strings.Lane.List.title)
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.alert(store: store.scope(state: \.$alert, action: { .view(.alert($0)) }))
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.sheet(store: store.scope(state: \.$addLaneForm, action: { .internal(.addLaneForm($0)) })) {
+		.alert(store: store.scope(state: \.$alert, action: \.view.alert))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.sheet(store: store.scope(state: \.$addLaneForm, action: \.internal.addLaneForm)) {
 			AddLaneFormView(store: $0)
 				.padding()
 				.overlay {

--- a/ios/Approach/Sources/AlleysListFeature/AlleysList.swift
+++ b/ios/Approach/Sources/AlleysListFeature/AlleysList.swift
@@ -83,10 +83,10 @@ public struct AlleysList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.editor, action: /Action.editor) {
+			Scope(state: \.editor, action: \.editor) {
 				AlleyEditor()
 			}
-			Scope(state: /State.filters, action: /Action.filters) {
+			Scope(state: \.filters, action: \.filters) {
 				AlleysFilter()
 			}
 		}
@@ -104,11 +104,11 @@ public struct AlleysList: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			ResourceList { request in
 				alleys.filteredList(
 					withMaterial: request.filter.material,
@@ -208,7 +208,7 @@ public struct AlleysList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/AlleysListFeature/AlleysList.swift
+++ b/ios/Approach/Sources/AlleysListFeature/AlleysList.swift
@@ -48,17 +48,17 @@ public struct AlleysList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didTapFiltersButton
 			case didTapBowler
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 
-		public enum InternalAction: Equatable {
-			case didLoadEditableAlley(TaskResult<Alley.EditWithLanes>)
-			case didDeleteAlley(TaskResult<Alley.List>)
+		@CasePathable public enum InternalAction {
+			case didLoadEditableAlley(Result<Alley.EditWithLanes, Error>)
+			case didDeleteAlley(Result<Alley.List, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 			case list(ResourceList<Alley.List, Alley.List.FetchRequest>.Action)
@@ -77,7 +77,7 @@ public struct AlleysList: Reducer {
 			case filters(AlleysFilter.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case editor(AlleyEditor.Action)
 			case filters(AlleysFilter.Action)
 		}
@@ -156,14 +156,14 @@ public struct AlleysList: Reducer {
 					switch delegateAction {
 					case let .didEdit(alley):
 						return .run { send in
-							await send(.internal(.didLoadEditableAlley(TaskResult {
+							await send(.internal(.didLoadEditableAlley(Result {
 								try await alleys.edit(alley.id)
 							})))
 						}
 
 					case let .didDelete(alley):
 						return .run { send in
-							await send(.internal(.didDeleteAlley(TaskResult {
+							await send(.internal(.didDeleteAlley(Result {
 								try await alleys.delete(alley.id)
 								return alley
 							})))

--- a/ios/Approach/Sources/AlleysListFeature/AlleysListView.swift
+++ b/ios/Approach/Sources/AlleysListFeature/AlleysListView.swift
@@ -2,6 +2,7 @@ import AlleyEditorFeature
 import AssetsLibrary
 import ComposableArchitecture
 import ErrorsFeature
+import ExtensionsLibrary
 import FeatureActionLibrary
 import ModelsLibrary
 import ModelsViewsLibrary
@@ -33,7 +34,7 @@ public struct AlleysListView: View {
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			ResourceListView(
-				store: store.scope(state: \.list, action: /AlleysList.Action.InternalAction.list)
+				store: store.scope(state: \.list, action: \.internal.list)
 			) { alley in
 				if viewStore.isShowingAverages {
 					VStack {
@@ -56,26 +57,9 @@ public struct AlleysListView: View {
 				}
 			}
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /AlleysList.Destination.State.editor,
-			action: AlleysList.Destination.Action.editor
-		) { store in
-			NavigationStack {
-				AlleyEditorView(store: store)
-			}
-		}
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /AlleysList.Destination.State.filters,
-			action: AlleysList.Destination.Action.filters
-		) { store in
-			NavigationStack {
-				AlleysFilterView(store: store)
-			}
-			.presentationDetents([.medium, .large])
-		}
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.alleyEditor(store.scope(state: \.$destination.editor, action: \.internal.destination.editor))
+		.alleysFilter(store.scope(state: \.$destination.filters, action: \.internal.destination.filters))
 	}
 
 	@MainActor @ViewBuilder private func header(
@@ -93,6 +77,25 @@ public struct AlleysListView: View {
 			}
 		} else {
 			EmptyView()
+		}
+	}
+}
+
+@MainActor extension View {
+	fileprivate func alleyEditor(_ store: PresentationStoreOf<AlleyEditor>) -> some View {
+		sheet(store: store) { store in
+			NavigationStack {
+				AlleyEditorView(store: store)
+			}
+		}
+	}
+
+	fileprivate func alleysFilter(_ store: PresentationStoreOf<AlleysFilter>) -> some View {
+		sheet(store: store) { store in
+			NavigationStack {
+				AlleysFilterView(store: store)
+			}
+			.presentationDetents([.medium, .large])
 		}
 	}
 }

--- a/ios/Approach/Sources/AlleysListFeature/Filter/AlleysFilter.swift
+++ b/ios/Approach/Sources/AlleysListFeature/Filter/AlleysFilter.swift
@@ -12,16 +12,16 @@ public struct AlleysFilter: Reducer {
 		@BindingState public var filter: Alley.List.FetchRequest.Filter
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didTapClearButton
 			case didTapApplyButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didChangeFilters(Alley.List.FetchRequest.Filter)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case `internal`(InternalAction)

--- a/ios/Approach/Sources/AlleysListFeature/Filter/AlleysFilter.swift
+++ b/ios/Approach/Sources/AlleysListFeature/Filter/AlleysFilter.swift
@@ -33,7 +33,7 @@ public struct AlleysFilter: Reducer {
 	@Dependency(\.dismiss) var dismiss
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/AnnouncementsFeature/Announcements.swift
+++ b/ios/Approach/Sources/AnnouncementsFeature/Announcements.swift
@@ -13,15 +13,15 @@ public struct Announcements: Reducer {
 		public init() {}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onFirstAppear
 			case didFinishDismissingAnnouncement
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 
-		@CasePathable public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case showChristmasAnnouncement
 			case destination(PresentationAction<Christmas2023Announcement.Action>)
 		}

--- a/ios/Approach/Sources/AnnouncementsFeature/Christmas2023Announcement.swift
+++ b/ios/Approach/Sources/AnnouncementsFeature/Christmas2023Announcement.swift
@@ -20,16 +20,16 @@ public struct Christmas2023Announcement: Reducer {
 	}
 
 	public struct State: Equatable {}
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onFirstAppear
 			case didTapOpenAppSettings
 			case didTapDismiss
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case openAppIconSettings
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/AppFeature/App.swift
+++ b/ios/Approach/Sources/AppFeature/App.swift
@@ -28,10 +28,10 @@ public struct App: Reducer {
 	}
 
 	public enum Action: FeatureAction {
-		public enum ViewAction {
+		@CasePathable public enum ViewAction {
 			case didFirstAppear
 		}
-		public enum DelegateAction { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 		@CasePathable public enum InternalAction {
 			case onboarding(Onboarding.Action)
 			case content(TabbedContent.Action)

--- a/ios/Approach/Sources/AppFeature/TabbedContent.swift
+++ b/ios/Approach/Sources/AppFeature/TabbedContent.swift
@@ -22,12 +22,12 @@ public struct TabbedContent: Reducer {
 	}
 
 	public enum Action: FeatureAction {
-		public enum ViewAction: BindableAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didAppear
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction { case doNothing }
-		public enum InternalAction {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case didChangeTabs([Tab])
 			case accessories(AccessoriesOverview.Action)
 			case bowlersList(BowlersList.Action)

--- a/ios/Approach/Sources/AppFeature/TabbedContent.swift
+++ b/ios/Approach/Sources/AppFeature/TabbedContent.swift
@@ -62,7 +62,7 @@ public struct TabbedContent: Reducer {
 	@Dependency(\.featureFlags) var featureFlags
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.bowlersList, action: /Action.internal..Action.InternalAction.bowlersList) {
 			BowlersList()

--- a/ios/Approach/Sources/AppFeature/TabbedContent.swift
+++ b/ios/Approach/Sources/AppFeature/TabbedContent.swift
@@ -64,19 +64,19 @@ public struct TabbedContent: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.bowlersList, action: /Action.internal..Action.InternalAction.bowlersList) {
+		Scope(state: \.bowlersList, action: \.internal.bowlersList) {
 			BowlersList()
 		}
 
-		Scope(state: \.settings, action: /Action.internal..Action.InternalAction.settings) {
+		Scope(state: \.settings, action: \.internal.settings) {
 			Settings()
 		}
 
-		Scope(state: \.accessories, action: /Action.internal..Action.InternalAction.accessories) {
+		Scope(state: \.accessories, action: \.internal.accessories) {
 			AccessoriesOverview()
 		}
 
-		Scope(state: \.statistics, action: /Action.internal..Action.InternalAction.statistics) {
+		Scope(state: \.statistics, action: \.internal.statistics) {
 			StatisticsOverview()
 		}
 

--- a/ios/Approach/Sources/AppFeature/TabbedContentView.swift
+++ b/ios/Approach/Sources/AppFeature/TabbedContentView.swift
@@ -31,19 +31,19 @@ public struct TabbedContentView: View {
 						switch tab {
 						case .overview:
 							BowlersListView(
-								store: store.scope(state: \.bowlersList, action: /TabbedContent.Action.InternalAction.bowlersList)
+								store: store.scope(state: \.bowlersList, action: \.internal.bowlersList)
 							)
 						case .statistics:
 							StatisticsOverviewView(
-								store: store.scope(state: \.statistics, action: /TabbedContent.Action.InternalAction.statistics)
+								store: store.scope(state: \.statistics, action: \.internal.statistics)
 							)
 						case .accessories:
 							AccessoriesOverviewView(
-								store: store.scope(state: \.accessories, action: /TabbedContent.Action.InternalAction.accessories)
+								store: store.scope(state: \.accessories, action: \.internal.accessories)
 							)
 						case .settings:
 							SettingsView(
-								store: store.scope(state: \.settings, action: /TabbedContent.Action.InternalAction.settings)
+								store: store.scope(state: \.settings, action: \.internal.settings)
 							)
 						}
 					}

--- a/ios/Approach/Sources/ArchiveListFeature/ArchiveList.swift
+++ b/ios/Approach/Sources/ArchiveListFeature/ArchiveList.swift
@@ -87,7 +87,7 @@ public struct ArchiveList: Reducer {
 	@Dependency(\.games) var games
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 

--- a/ios/Approach/Sources/ArchiveListFeature/ArchiveList.swift
+++ b/ios/Approach/Sources/ArchiveListFeature/ArchiveList.swift
@@ -42,22 +42,22 @@ public struct ArchiveList: Reducer {
 		public init() {}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case observeData
 			case didSwipe(ArchiveItem)
 			case alert(PresentationAction<AlertAction>)
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case bowlersResponse(TaskResult<[Bowler.Archived]>)
-			case leaguesResponse(TaskResult<[League.Archived]>)
-			case seriesResponse(TaskResult<[Series.Archived]>)
-			case gamesResponse(TaskResult<[Game.Archived]>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case bowlersResponse(Result<[Bowler.Archived], Error>)
+			case leaguesResponse(Result<[League.Archived], Error>)
+			case seriesResponse(Result<[Series.Archived], Error>)
+			case gamesResponse(Result<[Game.Archived], Error>)
 
-			case unarchived(TaskResult<ArchiveItem>)
+			case unarchived(Result<ArchiveItem, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 		}
@@ -108,7 +108,7 @@ public struct ArchiveList: Reducer {
 
 				case let .didSwipe(item):
 					return .run { send in
-						await send(.internal(.unarchived(TaskResult {
+						await send(.internal(.unarchived(Result {
 							switch item.id {
 							case let .bowler(bowlerId):
 								try await self.bowlers.unarchive(bowlerId)

--- a/ios/Approach/Sources/ArchiveListFeature/ArchiveListView.swift
+++ b/ios/Approach/Sources/ArchiveListFeature/ArchiveListView.swift
@@ -36,7 +36,7 @@ public struct ArchiveListView: View {
 			.navigationTitle(Strings.Archive.title)
 			.task { await viewStore.send(.observeData).finish() }
 			.onAppear { viewStore.send(.onAppear) }
-			.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+			.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 			.alert(store: store.scope(state: \.$alert, action: { .view(.alert($0)) }))
 		})
 	}

--- a/ios/Approach/Sources/AvatarEditorFeature/AvatarEditor.swift
+++ b/ios/Approach/Sources/AvatarEditorFeature/AvatarEditor.swift
@@ -96,7 +96,7 @@ public struct AvatarEditor: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/AvatarEditorFeature/AvatarEditor.swift
+++ b/ios/Approach/Sources/AvatarEditorFeature/AvatarEditor.swift
@@ -59,8 +59,8 @@ public struct AvatarEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapCancel
 			case didTapDone
@@ -68,10 +68,10 @@ public struct AvatarEditor: Reducer {
 			case didTapSwapColorsButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didFinishEditing(Avatar.Summary?)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/BowlerEditorFeature/BowlerEditor.swift
+++ b/ios/Approach/Sources/BowlerEditorFeature/BowlerEditor.swift
@@ -37,13 +37,13 @@ public struct BowlerEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case form(BowlerForm.Action)
 		}
 

--- a/ios/Approach/Sources/BowlerEditorFeature/BowlerEditor.swift
+++ b/ios/Approach/Sources/BowlerEditorFeature/BowlerEditor.swift
@@ -61,7 +61,7 @@ public struct BowlerEditor: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
+		Scope(state: \.form, action: \.internal.form) {
 			BowlerForm()
 				.dependency(\.records, .init(
 					create: bowlers.create,

--- a/ios/Approach/Sources/BowlerEditorFeature/BowlerEditor.swift
+++ b/ios/Approach/Sources/BowlerEditorFeature/BowlerEditor.swift
@@ -59,7 +59,7 @@ public struct BowlerEditor: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
 			BowlerForm()

--- a/ios/Approach/Sources/BowlerEditorFeature/BowlerEditorView.swift
+++ b/ios/Approach/Sources/BowlerEditorFeature/BowlerEditorView.swift
@@ -20,7 +20,7 @@ public struct BowlerEditorView: View {
 
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
-			FormView(store: store.scope(state: \.form, action: /BowlerEditor.Action.InternalAction.form)) {
+			FormView(store: store.scope(state: \.form, action: \.internal.form)) {
 				Section(Strings.Editor.Fields.Details.title) {
 					TextField(
 						Strings.Editor.Fields.Details.name,

--- a/ios/Approach/Sources/BowlersListFeature/BowlersList.swift
+++ b/ios/Approach/Sources/BowlersListFeature/BowlersList.swift
@@ -130,19 +130,19 @@ public struct BowlersList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.editor, action: /Action.editor) {
+			Scope(state: \.editor, action: \.editor) {
 				BowlerEditor()
 			}
-			Scope(state: /State.leagues, action: /Action.leagues) {
+			Scope(state: \.leagues, action: \.leagues) {
 				LeaguesList()
 			}
-			Scope(state: /State.sortOrder, action: /Action.sortOrder) {
+			Scope(state: \.sortOrder, action: \.sortOrder) {
 				SortOrder()
 			}
-			Scope(state: /State.seriesEditor, action: /Action.seriesEditor) {
+			Scope(state: \.seriesEditor, action: \.seriesEditor) {
 				SeriesEditor()
 			}
-			Scope(state: /State.games, action: /Action.games) {
+			Scope(state: \.games, action: \.games) {
 				GamesList()
 			}
 		}
@@ -166,19 +166,19 @@ public struct BowlersList: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			ResourceList(fetchResources: bowlers.list)
 		}
 
-		Scope(state: \.widgets, action: /Action.internal..Action.InternalAction.widgets) {
+		Scope(state: \.widgets, action: \.internal.widgets) {
 			StatisticsWidgetLayout()
 		}
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.announcements, action: /Action.internal..Action.InternalAction.announcements) {
+		Scope(state: \.announcements, action: \.internal.announcements) {
 			Announcements()
 		}
 
@@ -330,7 +330,7 @@ public struct BowlersList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/BowlersListFeature/BowlersList.swift
+++ b/ios/Approach/Sources/BowlersListFeature/BowlersList.swift
@@ -82,8 +82,8 @@ public struct BowlersList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didStartTask
 			case didTapSortOrderButton
@@ -91,12 +91,12 @@ public struct BowlersList: Reducer {
 			case didTapQuickLaunchButton
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 
-		public enum InternalAction: Equatable {
-			case didLoadEditableBowler(TaskResult<Bowler.Edit>)
-			case didLoadQuickLaunch(TaskResult<QuickLaunchSource?>)
-			case didArchiveBowler(TaskResult<Bowler.List>)
+		@CasePathable public enum InternalAction {
+			case didLoadEditableBowler(Result<Bowler.Edit, Error>)
+			case didLoadQuickLaunch(Result<QuickLaunchSource?, Error>)
+			case didArchiveBowler(Result<Bowler.List, Error>)
 			case didSetIsShowingWidgets(Bool)
 
 			case list(ResourceList<Bowler.List, Bowler.Ordering>.Action)
@@ -121,7 +121,7 @@ public struct BowlersList: Reducer {
 			case games(GamesList.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case editor(BowlerEditor.Action)
 			case leagues(LeaguesList.Action)
 			case sortOrder(SortOrder<Bowler.Ordering>.Action)
@@ -276,14 +276,14 @@ public struct BowlersList: Reducer {
 					switch delegateAction {
 					case let .didEdit(bowler):
 						return .run { send in
-							await send(.internal(.didLoadEditableBowler(TaskResult {
+							await send(.internal(.didLoadEditableBowler(Result {
 								try await bowlers.edit(bowler.id)
 							})))
 						}
 
 					case let .didArchive(bowler):
 						return .run { send in
-							await send(.internal(.didArchiveBowler(TaskResult {
+							await send(.internal(.didArchiveBowler(Result {
 								try await bowlers.archive(bowler.id)
 								return bowler
 							})))

--- a/ios/Approach/Sources/BowlersListFeature/BowlersListView.swift
+++ b/ios/Approach/Sources/BowlersListFeature/BowlersListView.swift
@@ -3,6 +3,7 @@ import AssetsLibrary
 import BowlerEditorFeature
 import ComposableArchitecture
 import ErrorsFeature
+import ExtensionsLibrary
 import GamesListFeature
 import LeaguesListFeature
 import ModelsLibrary
@@ -43,7 +44,7 @@ public struct BowlersListView: View {
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			ResourceListView(
-				store: store.scope(state: \.list, action: /BowlersList.Action.InternalAction.list)
+				store: store.scope(state: \.list, action: \.internal.list)
 			) { bowler in
 				Button { viewStore.send(.didTapBowler(bowler.id)) } label: {
 					LabeledContent(bowler.name, value: format(average: bowler.average))
@@ -62,13 +63,13 @@ public struct BowlersListView: View {
 			.task { viewStore.send(.didStartTask) }
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.announcements(store: store.scope(state: \.announcements, action: { .internal(.announcements($0)) }))
-		.bowlerEditor(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.sortOrder(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.seriesEditor(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.leaguesList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.gamesList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.announcements(store: store.scope(state: \.announcements, action: \.internal.announcements))
+		.bowlerEditor(store.scope(state: \.$destination.editor, action: \.internal.destination.editor))
+		.sortOrder(store.scope(state: \.$destination.sortOrder, action: \.internal.destination.sortOrder))
+		.seriesEditor(store.scope(state: \.$destination.seriesEditor, action: \.internal.destination.seriesEditor))
+		.leaguesList(store.scope(state: \.$destination.leagues, action: \.internal.destination.leagues))
+		.gamesList(store.scope(state: \.$destination.games, action: \.internal.destination.games))
 	}
 
 	@ViewBuilder private func quickLaunch(
@@ -119,7 +120,7 @@ public struct BowlersListView: View {
 	) -> some View {
 		if viewStore.isShowingWidgets {
 			Section {
-				StatisticsWidgetLayoutView(store: store.scope(state: \.widgets, action: { .internal(.widgets($0)) }))
+				StatisticsWidgetLayoutView(store: store.scope(state: \.widgets, action: \.internal.widgets))
 			}
 			.listRowSeparator(.hidden)
 			.listRowInsets(EdgeInsets())
@@ -130,27 +131,16 @@ public struct BowlersListView: View {
 }
 
 @MainActor extension View {
-	fileprivate typealias State = PresentationState<BowlersList.Destination.State>
-	fileprivate typealias Action = PresentationAction<BowlersList.Destination.Action>
-
-	fileprivate func bowlerEditor(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /BowlersList.Destination.State.editor,
-			action: BowlersList.Destination.Action.editor
-		) { (store: StoreOf<BowlerEditor>) in
+	fileprivate func bowlerEditor(_ store: PresentationStoreOf<BowlerEditor>) -> some View {
+		sheet(store: store) { (store: StoreOf<BowlerEditor>) in
 			NavigationStack {
 				BowlerEditorView(store: store)
 			}
 		}
 	}
 
-	fileprivate func sortOrder(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /BowlersList.Destination.State.sortOrder,
-			action: BowlersList.Destination.Action.sortOrder
-		) { (store: StoreOf<SortOrderLibrary.SortOrder<Bowler.Ordering>>) in
+	fileprivate func sortOrder(_ store: PresentationStoreOf<SortOrderLibrary.SortOrder<Bowler.Ordering>>) -> some View {
+		sheet(store: store) { (store: StoreOf<SortOrderLibrary.SortOrder<Bowler.Ordering>>) in
 			NavigationStack {
 				SortOrderView(store: store)
 			}
@@ -158,34 +148,22 @@ public struct BowlersListView: View {
 		}
 	}
 
-	fileprivate func seriesEditor(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /BowlersList.Destination.State.seriesEditor,
-			action: BowlersList.Destination.Action.seriesEditor
-		) { (store: StoreOf<SeriesEditor>) in
+	fileprivate func seriesEditor(_ store: PresentationStoreOf<SeriesEditor>) -> some View {
+		sheet(store: store) { (store: StoreOf<SeriesEditor>) in
 			NavigationStack {
 				SeriesEditorView(store: store)
 			}
 		}
 	}
 
-	fileprivate func leaguesList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /BowlersList.Destination.State.leagues,
-			action: BowlersList.Destination.Action.leagues
-		) { (store: StoreOf<LeaguesList>) in
+	fileprivate func leaguesList(_ store: PresentationStoreOf<LeaguesList>) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<LeaguesList>) in
 			LeaguesListView(store: store)
 		}
 	}
 
-	fileprivate func gamesList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /BowlersList.Destination.State.games,
-			action: BowlersList.Destination.Action.games
-		) { (store: StoreOf<GamesList>) in
+	fileprivate func gamesList(_ store: PresentationStoreOf<GamesList>) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<GamesList>) in
 			GamesListView(store: store)
 		}
 	}

--- a/ios/Approach/Sources/ErrorsFeature/ErrorReport.swift
+++ b/ios/Approach/Sources/ErrorsFeature/ErrorReport.swift
@@ -76,7 +76,7 @@ public struct ErrorReport: Reducer {
 	@Dependency(\.pasteboard) var pasteboard
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/ErrorsFeature/ErrorReport.swift
+++ b/ios/Approach/Sources/ErrorsFeature/ErrorReport.swift
@@ -47,16 +47,16 @@ public struct ErrorReport: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapCopyErrorButton
 			case didTapDismissButton
 			case didTapEmailButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case didCopyToClipboard
 			case toast(ToastAction)
 		}

--- a/ios/Approach/Sources/ErrorsFeature/ErrorReport.swift
+++ b/ios/Approach/Sources/ErrorsFeature/ErrorReport.swift
@@ -256,7 +256,7 @@ public struct ErrorReportView: View {
 			}
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.toast(store: store.scope(state: \.toast, action: { .internal(.toast($0)) }))
+		.toast(store: store.scope(state: \.toast, action: \.internal.toast))
 	}
 }
 

--- a/ios/Approach/Sources/ErrorsFeature/Errors.swift
+++ b/ios/Approach/Sources/ErrorsFeature/Errors.swift
@@ -137,7 +137,7 @@ public struct Errors<ErrorID: Hashable>: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$report, action: /Action.internal..Action.InternalAction.report) {
+		.ifLet(\.$report, action: \.internal.report) {
 			ErrorReport()
 		}
 	}
@@ -194,9 +194,9 @@ extension View {
 		store: Store<Errors<ErrorID>.State, Errors<ErrorID>.Action>
 	) -> some View {
 		self
-			.toast(store: store.scope(state: \.currentToast, action: { .internal(.toast($0)) }))
+			.toast(store: store.scope(state: \.currentToast, action: \.internal.toast))
 			.sheet(
-				store: store.scope(state: \.$report, action: { .internal(.report($0)) }),
+				store: store.scope(state: \.$report, action: \.internal.report),
 				onDismiss: { store.send(.view(.didFinishDismissingReport)) },
 				content: { store in
 					ErrorReportView(store: store)

--- a/ios/Approach/Sources/ErrorsFeature/Errors.swift
+++ b/ios/Approach/Sources/ErrorsFeature/Errors.swift
@@ -46,12 +46,12 @@ public struct Errors<ErrorID: Hashable>: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didFinishDismissingReport
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case didReceiveReport(AlwaysEqual<Report>)
 
 			case toast(ToastAction)

--- a/ios/Approach/Sources/FeatureFlagsListFeature/FeatureFlagList.swift
+++ b/ios/Approach/Sources/FeatureFlagsListFeature/FeatureFlagList.swift
@@ -11,8 +11,8 @@ public struct FeatureFlagsList: Reducer {
 		public init() {}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didStartObservingFlags
 			case didToggle(FeatureFlag)
 			case didTapResetOverridesButton
@@ -20,8 +20,8 @@ public struct FeatureFlagsList: Reducer {
 			case didTapMatchDevelopmentButton
 			case didTapMatchTestButton
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case didLoadFlags([FeatureFlagItem])
 		}
 

--- a/ios/Approach/Sources/FormFeature/Form.swift
+++ b/ios/Approach/Sources/FormFeature/Form.swift
@@ -197,7 +197,7 @@ public struct Form<
 	@Dependency(\.records) var records
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 

--- a/ios/Approach/Sources/FormFeature/Form.swift
+++ b/ios/Approach/Sources/FormFeature/Form.swift
@@ -99,7 +99,7 @@ public struct Form<
 			self = .init(initialValue: initialValue, currentValue: initialValue)
 		}
 
-		public mutating func didFinishCreating(_ record: TaskResult<New>) -> Effect<Form.Action> {
+		public mutating func didFinishCreating(_ record: Result<New, Error>) -> Effect<Form.Action> {
 			isLoading = false
 			switch record {
 			case let .success(new):
@@ -111,7 +111,7 @@ public struct Form<
 			}
 		}
 
-		public mutating func didFinishUpdating(_ record: TaskResult<Existing>) -> Effect<Form.Action> {
+		public mutating func didFinishUpdating(_ record: Result<Existing, Error>) -> Effect<Form.Action> {
 			isLoading = false
 			switch record {
 			case let .success(existing):
@@ -123,7 +123,7 @@ public struct Form<
 			}
 		}
 
-		public mutating func didFinishDeleting(_ record: TaskResult<Existing>) -> Effect<Form.Action> {
+		public mutating func didFinishDeleting(_ record: Result<Existing, Error>) -> Effect<Form.Action> {
 			isLoading = false
 			switch record {
 			case let .success(existing):
@@ -135,7 +135,7 @@ public struct Form<
 			}
 		}
 
-		public mutating func didFinishArchiving(_ record: TaskResult<Existing>) -> Effect<Form.Action> {
+		public mutating func didFinishArchiving(_ record: Result<Existing, Error>) -> Effect<Form.Action> {
 			isLoading = false
 			switch record {
 			case let .success(existing):
@@ -148,8 +148,8 @@ public struct Form<
 		}
 	}
 
-	public enum Action: Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action {
+		@CasePathable public enum ViewAction {
 			case didTapSaveButton
 			case didTapDiscardButton
 			case didTapDeleteButton
@@ -157,15 +157,15 @@ public struct Form<
 			case alert(PresentationAction<AlertAction>)
 		}
 
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case errors(Errors<ErrorID>.Action)
 		}
 
-		public enum DelegateAction: Equatable {
-			case didCreate(TaskResult<New>)
-			case didUpdate(TaskResult<Existing>)
-			case didDelete(TaskResult<Existing>)
-			case didArchive(TaskResult<Existing>)
+		@CasePathable public enum DelegateAction {
+			case didCreate(Result<New, Error>)
+			case didUpdate(Result<Existing, Error>)
+			case didDelete(Result<Existing, Error>)
+			case didArchive(Result<Existing, Error>)
 			case didFinishCreating(New)
 			case didFinishUpdating(Existing)
 			case didFinishDeleting(Existing)
@@ -213,7 +213,7 @@ public struct Form<
 					switch state.value {
 					case let .edit(existing):
 						return .run { send in
-							await send(.delegate(.didUpdate(TaskResult {
+							await send(.delegate(.didUpdate(Result {
 								try await records.update?(existing)
 								return existing
 							})))
@@ -221,7 +221,7 @@ public struct Form<
 
 					case let .create(new):
 						return .run { send in
-							await send(.delegate(.didCreate(TaskResult {
+							await send(.delegate(.didCreate(Result {
 								try await records.create?(new)
 								return new
 							})))
@@ -266,7 +266,7 @@ public struct Form<
 						guard case let .edit(record) = state.initialValue else { return .none }
 						state.isLoading = true
 						return .run { send in
-							await send(.delegate(.didDelete(TaskResult {
+							await send(.delegate(.didDelete(Result {
 								try await records.delete?(record.id)
 								return record
 							})))
@@ -276,7 +276,7 @@ public struct Form<
 						guard case let .edit(record) = state.initialValue else { return .none }
 						state.isLoading = true
 						return .run { send in
-							await send(.delegate(.didArchive(TaskResult {
+							await send(.delegate(.didArchive(Result {
 								try await records.archive?(record.id)
 								return record
 							})))

--- a/ios/Approach/Sources/FormFeature/Form.swift
+++ b/ios/Approach/Sources/FormFeature/Form.swift
@@ -304,6 +304,6 @@ public struct Form<
 				return .none
 			}
 		}
-		.ifLet(\.$alert, action: /Action.view..Action.ViewAction.alert)
+		.ifLet(\.$alert, action: \.view.alert)
 	}
 }

--- a/ios/Approach/Sources/FormFeature/FormView.swift
+++ b/ios/Approach/Sources/FormFeature/FormView.swift
@@ -85,7 +85,7 @@ public struct FormView<
 				}
 			}
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 		.alert(store: store.scope(state: \.$alert, action: { .view(.alert($0)) }))
 	}
 }

--- a/ios/Approach/Sources/GamesEditorFeature/Frame/FrameEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Frame/FrameEditor.swift
@@ -24,18 +24,18 @@ public struct FrameEditor: Reducer {
 		}
 	}
 
-	public enum Action: Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action {
+		@CasePathable public enum ViewAction {
 			case didStartDragging
 			case didDragOverPin(Pin)
 			case didStopDragging
 			case didTapPin(Pin)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didProvokeLock
 			case didEditFrame
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/GamesEditorFeature/Game/GameDetails+Extensions.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Game/GameDetails+Extensions.swift
@@ -16,7 +16,7 @@ extension GameDetails {
 
 	func createMatchPlay(_ matchPlay: MatchPlay.Edit) -> Effect<Action> {
 		return .run { send in
-			await send(.delegate(.didEditMatchPlay(TaskResult {
+			await send(.delegate(.didEditMatchPlay(Result {
 				try await matchPlays.create(matchPlay)
 				return matchPlay
 			})))
@@ -29,7 +29,7 @@ extension GameDetails {
 		return .concatenate(
 			.cancel(id: CancelID.saveMatchPlay),
 			.run { send in
-				await send(.delegate(.didEditMatchPlay(TaskResult {
+				await send(.delegate(.didEditMatchPlay(Result {
 					try await matchPlays.delete(matchPlay.id)
 					return nil
 				})))

--- a/ios/Approach/Sources/GamesEditorFeature/Game/GameDetails.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Game/GameDetails.swift
@@ -108,19 +108,19 @@ public struct GameDetails: Reducer {
 		@Dependency(\.lanes) var lanes
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.lanePicker, action: /Action.lanePicker) {
+			Scope(state: \.lanePicker, action: \.lanePicker) {
 				ResourcePicker { alley in lanes.list(alley) }
 			}
-			Scope(state: /State.gearPicker, action: /Action.gearPicker) {
+			Scope(state: \.gearPicker, action: \.gearPicker) {
 				ResourcePicker { _ in gear.list(ordered: .byName) }
 			}
-			Scope(state: /State.matchPlay, action: /Action.matchPlay) {
+			Scope(state: \.matchPlay, action: \.matchPlay) {
 				MatchPlayEditor()
 			}
-			Scope(state: /State.scoring, action: /Action.scoring) {
+			Scope(state: \.scoring, action: \.scoring) {
 				ScoringEditor()
 			}
-			Scope(state: /State.statistics, action: /Action.statistics) {
+			Scope(state: \.statistics, action: \.statistics) {
 				MidGameStatisticsDetails()
 			}
 		}
@@ -137,7 +137,7 @@ public struct GameDetails: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.gameDetailsHeader, action: /Action.internal..Action.InternalAction.gameDetailsHeader) {
+		Scope(state: \.gameDetailsHeader, action: \.internal.gameDetailsHeader) {
 			GameDetailsHeader()
 		}
 
@@ -317,7 +317,7 @@ public struct GameDetails: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/GamesEditorFeature/Game/GameDetails.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Game/GameDetails.swift
@@ -49,8 +49,8 @@ public struct GameDetails: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case task
 			case onAppear
 			case didFirstAppear
@@ -65,19 +65,19 @@ public struct GameDetails: Reducer {
 			case didMeasureMinimumSheetContentSize(CGSize)
 			case didMeasureSectionHeaderContentSize(CGSize)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didSelectLanes
 			case didProceed(to: GameDetailsHeader.State.NextElement)
-			case didEditMatchPlay(TaskResult<MatchPlay.Edit?>)
+			case didEditMatchPlay(Result<MatchPlay.Edit?, Error>)
 			case didClearManualScore
 			case didProvokeLock
 			case didEditGame(Game.Edit?)
 			case didMeasureMinimumSheetContentSize(CGSize)
 			case didMeasureSectionHeaderContentSize(CGSize)
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case refreshObservation
-			case didLoadGame(TaskResult<Game.Edit?>)
+			case didLoadGame(Result<Game.Edit?, Error>)
 			case gameDetailsHeader(GameDetailsHeader.Action)
 			case destination(PresentationAction<Destination.Action>)
 		}
@@ -96,7 +96,7 @@ public struct GameDetails: Reducer {
 			case scoring(ScoringEditor.State)
 			case statistics(MidGameStatisticsDetails.State)
 		}
-		public enum Action: Equatable {
+		public enum Action {
 			case lanePicker(ResourcePicker<Lane.Summary, Alley.ID>.Action)
 			case gearPicker(ResourcePicker<Gear.Summary, AlwaysEqual<Void>>.Action)
 			case matchPlay(MatchPlayEditor.Action)

--- a/ios/Approach/Sources/GamesEditorFeature/Game/GameDetailsHeader.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Game/GameDetailsHeader.swift
@@ -28,17 +28,17 @@ public struct GameDetailsHeader: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didStartTask
 			case didTapNext(State.NextElement)
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case startShimmering
 			case setShimmerColor(Color?)
 			case setFlashEditorChangesEnabled(Bool)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didProceed(to: State.NextElement)
 		}
 

--- a/ios/Approach/Sources/GamesEditorFeature/Game/GameDetailsView.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Game/GameDetailsView.swift
@@ -2,6 +2,7 @@ import AssetsLibrary
 import AvatarServiceInterface
 import ComposableArchitecture
 import EquatableLibrary
+import ExtensionsLibrary
 import ModelsLibrary
 import ResourcePickerLibrary
 import StatisticsDetailsFeature
@@ -95,53 +96,11 @@ public struct GameDetailsView: View {
 				.onFirstAppear { viewStore.send(.didFirstAppear) }
 			})
 			.toolbar(.hidden)
-			.navigationDestination(
-				store: store.scope(state: \.$destination, action: \.internal.destination)
-			) {
-				SwitchStore($0) { state in
-					switch state {
-					case .gearPicker:
-						CaseLet(
-							/GameDetails.Destination.State.gearPicker,
-							 action: GameDetails.Destination.Action.gearPicker
-						) {
-							ResourcePickerView(store: $0) {
-								Gear.ViewWithAvatar($0)
-							}
-						}
-					case .lanePicker:
-						CaseLet(
-							/GameDetails.Destination.State.lanePicker,
-							 action: GameDetails.Destination.Action.lanePicker
-						) {
-							ResourcePickerView(store: $0) {
-								Lane.View($0)
-							}
-						}
-					case .matchPlay:
-						CaseLet(
-							/GameDetails.Destination.State.matchPlay,
-							 action: GameDetails.Destination.Action.matchPlay
-						) {
-							MatchPlayEditorView(store: $0)
-						}
-					case .scoring:
-						CaseLet(
-							/GameDetails.Destination.State.scoring,
-							 action: GameDetails.Destination.Action.scoring
-						) {
-							ScoringEditorView(store: $0)
-						}
-					case .statistics:
-						CaseLet(
-							/GameDetails.Destination.State.statistics,
-							 action: GameDetails.Destination.Action.statistics
-						) {
-							MidGameStatisticsDetailsView(store: $0)
-						}
-					}
-				}
-			}
+			.gearPicker(store.scope(state: \.$destination.gearPicker, action: \.internal.destination.gearPicker))
+			.lanePicker(store.scope(state: \.$destination.lanePicker, action: \.internal.destination.lanePicker))
+			.matchPlay(store.scope(state: \.$destination.matchPlay, action: \.internal.destination.matchPlay))
+			.scoring(store.scope(state: \.$destination.scoring, action: \.internal.destination.scoring))
+			.statistics(store.scope(state: \.$destination.statistics, action: \.internal.destination.statistics))
 		}
 	}
 
@@ -168,6 +127,44 @@ public struct GameDetailsView: View {
 					Text(Strings.Game.Editor.Fields.ExcludeFromStatistics.help)
 				}
 			}
+		}
+	}
+}
+
+@MainActor extension View {
+	fileprivate func gearPicker(
+		_ store: PresentationStoreOf<ResourcePicker<Gear.Summary, AlwaysEqual<Void>>>
+	) -> some View {
+		navigationDestination(store: store) {
+			ResourcePickerView(store: $0) {
+				Gear.ViewWithAvatar($0)
+			}
+		}
+	}
+
+	fileprivate func lanePicker(_ store: PresentationStoreOf<ResourcePicker<Lane.Summary, Alley.ID>>) -> some View {
+		navigationDestination(store: store) {
+			ResourcePickerView(store: $0) {
+				Lane.View($0)
+			}
+		}
+	}
+
+	fileprivate func matchPlay(_ store: PresentationStoreOf<MatchPlayEditor>) -> some View {
+		navigationDestination(store: store) {
+			MatchPlayEditorView(store: $0)
+		}
+	}
+
+	fileprivate func scoring(_ store: PresentationStoreOf<ScoringEditor>) -> some View {
+		navigationDestination(store: store) {
+			ScoringEditorView(store: $0)
+		}
+	}
+
+	fileprivate func statistics(_ store: PresentationStoreOf<MidGameStatisticsDetails>) -> some View {
+		navigationDestination(store: store) {
+			MidGameStatisticsDetailsView(store: $0)
 		}
 	}
 }

--- a/ios/Approach/Sources/GamesEditorFeature/Game/GameDetailsView.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Game/GameDetailsView.swift
@@ -22,7 +22,7 @@ public struct GameDetailsView: View {
 				Form {
 					Section {
 						GameDetailsHeaderView(
-							store: store.scope(state: \.gameDetailsHeader, action: /GameDetails.Action.InternalAction.gameDetailsHeader)
+							store: store.scope(state: \.gameDetailsHeader, action: \.internal.gameDetailsHeader)
 						)
 						.listRowInsets(EdgeInsets())
 						.listRowBackground(Color.clear)
@@ -96,7 +96,7 @@ public struct GameDetailsView: View {
 			})
 			.toolbar(.hidden)
 			.navigationDestination(
-				store: store.scope(state: \.$destination, action: { .internal(.destination($0)) })
+				store: store.scope(state: \.$destination, action: \.internal.destination)
 			) {
 				SwitchStore($0) { state in
 					switch state {

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Destination.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Destination.swift
@@ -17,7 +17,7 @@ extension GamesEditor {
 			case sharing(Sharing.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case settings(GamesSettings.Action)
 			case ballPicker(ResourcePicker<Gear.Summary, AlwaysEqual<Void>>.Action)
 			case sharing(Sharing.Action)
@@ -47,7 +47,7 @@ extension GamesEditor {
 			case sheets(SheetsDestination.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case gameDetails(GameDetails.Action)
 			case duplicateLanesAlert(AlertAction)
 			case sheets(SheetsDestination.Action)

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Destination.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Destination.swift
@@ -27,13 +27,13 @@ extension GamesEditor {
 		@Dependency(\.gear) var gear
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.settings, action: /Action.settings) {
+			Scope(state: \.settings, action: \.settings) {
 				GamesSettings()
 			}
-			Scope(state: /State.ballPicker, action: /Action.ballPicker) {
+			Scope(state: \.ballPicker, action: \.ballPicker) {
 				ResourcePicker { _ in gear.list(ofKind: .bowlingBall, ordered: .byName) }
 			}
-			Scope(state: /State.sharing, action: /Action.sharing) {
+			Scope(state: \.sharing, action: \.sharing) {
 				Sharing()
 			}
 		}
@@ -59,10 +59,10 @@ extension GamesEditor {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.gameDetails, action: /Action.gameDetails) {
+			Scope(state: \.gameDetails, action: \.gameDetails) {
 				GameDetails()
 			}
-			Scope(state: /State.sheets, action: /Action.sheets) {
+			Scope(state: \.sheets, action: \.sheets) {
 				SheetsDestination()
 			}
 		}

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Effects.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor+Effects.swift
@@ -7,7 +7,7 @@ extension GamesEditor {
 	func loadBowlers(state: inout State) -> Effect<Action> {
 		state.elementsRefreshing.insert(.bowlers)
 		return .run { [bowlerIds = state.bowlerIds] send in
-			await send(.internal(.bowlersResponse(TaskResult {
+			await send(.internal(.bowlersResponse(Result {
 				try await bowlers.summaries(forIds: bowlerIds)
 			})))
 		}

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
@@ -100,8 +100,8 @@ public struct GamesEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didFirstAppear
 			case didAdjustBackdropSize(CGSize)
@@ -110,16 +110,16 @@ public struct GamesEditor: Reducer {
 			case didRequestReview
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case bowlersResponse(TaskResult<[Bowler.Summary]>)
-			case framesResponse(TaskResult<[Frame.Edit]>)
-			case gameResponse(TaskResult<Game.Edit?>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case bowlersResponse(Result<[Bowler.Summary], Error>)
+			case framesResponse(Result<[Frame.Edit], Error>)
+			case gameResponse(Result<Game.Edit?, Error>)
 
-			case didUpdateFrame(TaskResult<Frame.Edit>)
-			case didUpdateGame(TaskResult<Game.Edit>)
-			case didUpdateMatchPlay(TaskResult<MatchPlay.Edit>)
-			case didDuplicateLanes(TaskResult<Never>)
+			case didUpdateFrame(Result<Frame.Edit, Error>)
+			case didUpdateGame(Result<Game.Edit, Error>)
+			case didUpdateMatchPlay(Result<MatchPlay.Edit, Error>)
+			case didDuplicateLanes(Result<Never, Error>)
 
 			case showDuplicateLanesAlert
 

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
@@ -192,11 +192,11 @@ public struct GamesEditor: Reducer {
 			return save(frame: state.frames?[currentFrameIndex])
 		}
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.gamesHeader, action: /Action.internal..Action.InternalAction.gamesHeader) {
+		Scope(state: \.gamesHeader, action: \.internal.gamesHeader) {
 			GamesHeader()
 		}
 
@@ -430,13 +430,13 @@ public struct GamesEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.frameEditor, action: /Action.internal..Action.InternalAction.frameEditor) {
+		.ifLet(\.frameEditor, action: \.internal.frameEditor) {
 			FrameEditor()
 		}
-		.ifLet(\.rollEditor, action: /Action.internal..Action.InternalAction.rollEditor) {
+		.ifLet(\.rollEditor, action: \.internal.rollEditor) {
 			RollEditor()
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditor.swift
@@ -179,7 +179,7 @@ public struct GamesEditor: Reducer {
 	@Dependency(\.storeReview) var storeReview
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		// We explicitly handle this action before all others so that we can guarantee we are on a valid frame/roll
 		Reduce<State, Action> { state, action in

--- a/ios/Approach/Sources/GamesEditorFeature/GamesEditorView.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/GamesEditorView.swift
@@ -52,7 +52,7 @@ public struct GamesEditorView: View {
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			VStack {
-				GamesHeaderView(store: store.scope(state: \.gamesHeader, action: /GamesEditor.Action.InternalAction.gamesHeader))
+				GamesHeaderView(store: store.scope(state: \.gamesHeader, action: \.internal.gamesHeader))
 					.measure(key: HeaderContentSizeKey.self, to: $headerContentSize)
 
 				VStack {
@@ -114,7 +114,7 @@ public struct GamesEditorView: View {
 			.background(Color.black)
 			.toolbar(.hidden, for: .tabBar, .navigationBar)
 			.sheet(
-				store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
+				store: store.scope(state: \.$destination, action: \.internal.destination),
 				state: /GamesEditor.Destination.State.gameDetails,
 				action: GamesEditor.Destination.Action.gameDetails,
 				onDismiss: { viewStore.send(.didDismissGameDetails) },
@@ -142,14 +142,14 @@ public struct GamesEditorView: View {
 				}
 			}
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 		.alert(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
+			store: store.scope(state: \.$destination, action: \.internal.destination),
 			state: /GamesEditor.Destination.State.duplicateLanesAlert,
 			action: GamesEditor.Destination.Action.duplicateLanesAlert
 		)
 		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
+			store: store.scope(state: \.$destination, action: \.internal.destination),
 			state: /GamesEditor.Destination.State.sheets,
 			action: GamesEditor.Destination.Action.sheets,
 			onDismiss: { store.send(.view(.didDismissOpenSheet)) },
@@ -201,7 +201,7 @@ public struct GamesEditorView: View {
 			)
 			.presentationBackgroundInteraction(.enabled(upThrough: .medium))
 			.interactiveDismissDisabled(true)
-			.toast(store: store.scope(state: \.toast, action: { .internal(.toast($0)) }))
+			.toast(store: store.scope(state: \.toast, action: \.internal.toast))
 			.measure(key: SheetContentSizeKey.self, to: $sheetContentSize)
 	}
 
@@ -226,13 +226,13 @@ public struct GamesEditorView: View {
 	}
 
 	private var frameEditor: some View {
-		IfLetStore(store.scope(state: \.frameEditor, action: /GamesEditor.Action.InternalAction.frameEditor)) {
+		IfLetStore(store.scope(state: \.frameEditor, action: \.internal.frameEditor)) {
 			FrameEditorView(store: $0)
 		}
 	}
 
 	private var rollEditor: some View {
-		IfLetStore(store.scope(state: \.rollEditor, action: /GamesEditor.Action.InternalAction.rollEditor)) {
+		IfLetStore(store.scope(state: \.rollEditor, action: \.internal.rollEditor)) {
 			RollEditorView(store: $0)
 		}
 	}

--- a/ios/Approach/Sources/GamesEditorFeature/Manage/GamesHeader.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Manage/GamesHeader.swift
@@ -26,20 +26,20 @@ public struct GamesHeader: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didStartTask
 			case didTapCloseButton
 			case didTapSettingsButton
 			case didTapShareButton
 			case didStartShimmering
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didCloseEditor
 			case didOpenSettings
 			case didShareGame
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case setShimmerColor(Color?)
 			case setFlashEditorChangesEnabled(Bool)
 		}

--- a/ios/Approach/Sources/GamesEditorFeature/Manage/GamesSettings.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Manage/GamesSettings.swift
@@ -60,7 +60,7 @@ public struct GamesSettings: Reducer {
 	@Dependency(\.preferences) var preferences
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/GamesEditorFeature/Manage/GamesSettings.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Manage/GamesSettings.swift
@@ -35,8 +35,8 @@ public struct GamesSettings: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapDone
 			case didSwitchGame(to: Int)
@@ -44,12 +44,12 @@ public struct GamesSettings: Reducer {
 			case didMoveBowlers(source: IndexSet, destination: Int)
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case movedBowlers(source: IndexSet, destination: Int)
 			case switchedGame(to: Int)
 			case switchedBowler(to: Bowler.ID)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/GamesEditorFeature/MatchPlay/MatchPlayEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/MatchPlay/MatchPlayEditor.swift
@@ -110,7 +110,7 @@ public struct MatchPlayEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$opponentPicker, action: /Action.internal..Action.InternalAction.opponentPicker) {
+		.ifLet(\.$opponentPicker, action: \.internal.opponentPicker) {
 			ResourcePicker { _ in bowlers.opponents(ordering: .byName) }
 		}
 
@@ -183,7 +183,7 @@ public struct MatchPlayEditorView: View {
 		})
 		.navigationTitle(Strings.MatchPlay.title)
 		.navigationDestination(
-			store: store.scope(state: \.$opponentPicker, action: { .internal(.opponentPicker($0)) })
+			store: store.scope(state: \.$opponentPicker, action: \.internal.opponentPicker)
 		) { store in
 			ResourcePickerView(store: store) {
 				Bowler.View($0)

--- a/ios/Approach/Sources/GamesEditorFeature/MatchPlay/MatchPlayEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/MatchPlay/MatchPlayEditor.swift
@@ -25,18 +25,18 @@ public struct MatchPlayEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapOpponent
 			case didSetScore(String)
 			case didSetResult(MatchPlay.Result?)
 			case didTapDeleteButton
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didEditMatchPlay(MatchPlay.Edit?)
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case opponentPicker(PresentationAction<ResourcePicker<Bowler.Opponent, AlwaysEqual<Void>>.Action>)
 		}
 

--- a/ios/Approach/Sources/GamesEditorFeature/Roll/RollEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Roll/RollEditor.swift
@@ -26,17 +26,17 @@ public struct RollEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didStartTask
 			case didTapBall(Gear.ID)
 			case didTapOtherButton
 			case didToggleFoul
 		}
-		public enum InternalAction: Equatable {
-			case didLoadGear(TaskResult<[Gear.Summary]>)
+		@CasePathable public enum InternalAction {
+			case didLoadGear(Result<[Gear.Summary], Error>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didEditRoll
 			case didRequestBallPicker
 			case didChangeBall(Gear.Summary?)

--- a/ios/Approach/Sources/GamesEditorFeature/Scoring/ScoringEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Scoring/ScoringEditor.swift
@@ -12,17 +12,17 @@ public struct ScoringEditor: Reducer {
 		@BindingState public var score: Int
 	}
 
-	public enum Action: Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case toggleManualScoring(Bool)
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didSetManualScore(Int)
 			case didClearManualScore
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/GamesEditorFeature/Scoring/ScoringEditor.swift
+++ b/ios/Approach/Sources/GamesEditorFeature/Scoring/ScoringEditor.swift
@@ -34,7 +34,7 @@ public struct ScoringEditor: Reducer {
 	@Dependency(\.continuousClock) var clock
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/GamesListFeature/GamesList.swift
+++ b/ios/Approach/Sources/GamesListFeature/GamesList.swift
@@ -60,8 +60,8 @@ public struct GamesList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapGame(Game.ID)
 			case didTapShareButton
@@ -69,12 +69,12 @@ public struct GamesList: Reducer {
 			case didTapAddButton
 			case didTapArchiveTipDismissButton
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didLoadEditableSeries(TaskResult<Series.Edit>)
-			case didReorderGames(TaskResult<Never>)
-			case didAddGameToSeries(TaskResult<Never>)
-			case didArchiveGame(TaskResult<Never>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didLoadEditableSeries(Result<Series.Edit, Error>)
+			case didReorderGames(Result<Never, Error>)
+			case didAddGameToSeries(Result<Never, Error>)
+			case didArchiveGame(Result<Never, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 			case list(ResourceList<Game.List, Series.ID>.Action)
@@ -93,7 +93,7 @@ public struct GamesList: Reducer {
 			case seriesEditor(SeriesEditor.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case sharing(Sharing.Action)
 			case gameEditor(GamesEditor.Action)
 			case seriesEditor(SeriesEditor.Action)
@@ -163,7 +163,7 @@ public struct GamesList: Reducer {
 
 				case .didTapEditButton:
 					return .run { [id = state.series.id] send in
-						await send(.internal(.didLoadEditableSeries(TaskResult {
+						await send(.internal(.didLoadEditableSeries(Result {
 							try await self.series.edit(id)
 						})))
 					}

--- a/ios/Approach/Sources/GamesListFeature/GamesList.swift
+++ b/ios/Approach/Sources/GamesListFeature/GamesList.swift
@@ -100,13 +100,13 @@ public struct GamesList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.sharing, action: /Action.sharing) {
+			Scope(state: \.sharing, action: \.sharing) {
 				Sharing()
 			}
-			Scope(state: /State.gameEditor, action: /Action.gameEditor) {
+			Scope(state: \.gameEditor, action: \.gameEditor) {
 				GamesEditor()
 			}
-			Scope(state: /State.seriesEditor, action: /Action.seriesEditor) {
+			Scope(state: \.seriesEditor, action: \.seriesEditor) {
 				SeriesEditor()
 			}
 		}
@@ -131,11 +131,11 @@ public struct GamesList: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			ResourceList(fetchResources: fetchGames(seriesId:))
 		}
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
@@ -281,7 +281,7 @@ public struct GamesList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/GearEditorFeature/GearEditor.swift
+++ b/ios/Approach/Sources/GearEditorFeature/GearEditor.swift
@@ -53,15 +53,15 @@ public struct GearEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapOwner
 			case didTapAvatar
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case form(GearForm.Action)
 			case destination(PresentationAction<Destination.Action>)
 		}
@@ -78,7 +78,7 @@ public struct GearEditor: Reducer {
 			case avatar(AvatarEditor.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case bowlerPicker(ResourcePicker<Bowler.Summary, AlwaysEqual<Void>>.Action)
 			case avatar(AvatarEditor.Action)
 		}

--- a/ios/Approach/Sources/GearEditorFeature/GearEditor.swift
+++ b/ios/Approach/Sources/GearEditorFeature/GearEditor.swift
@@ -86,10 +86,10 @@ public struct GearEditor: Reducer {
 		@Dependency(\.bowlers) var bowlers
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.bowlerPicker, action: /Action.bowlerPicker) {
+			Scope(state: \.bowlerPicker, action: \.bowlerPicker) {
 				ResourcePicker { _ in bowlers.pickable() }
 			}
-			Scope(state: /State.avatar, action: /Action.avatar) {
+			Scope(state: \.avatar, action: \.avatar) {
 				AvatarEditor()
 			}
 		}
@@ -105,7 +105,7 @@ public struct GearEditor: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
+		Scope(state: \.form, action: \.internal.form) {
 			GearForm()
 				.dependency(\.records, .init(
 					create: gear.create,
@@ -183,7 +183,7 @@ public struct GearEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/GearEditorFeature/GearEditor.swift
+++ b/ios/Approach/Sources/GearEditorFeature/GearEditor.swift
@@ -103,7 +103,7 @@ public struct GearEditor: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
 			GearForm()

--- a/ios/Approach/Sources/GearEditorFeature/GearEditorView.swift
+++ b/ios/Approach/Sources/GearEditorFeature/GearEditorView.swift
@@ -1,6 +1,8 @@
 import AvatarEditorFeature
 import AvatarServiceInterface
 import ComposableArchitecture
+import EquatableLibrary
+import ExtensionsLibrary
 import FeatureActionLibrary
 import FormFeature
 import ModelsLibrary
@@ -28,7 +30,7 @@ public struct GearEditorView: View {
 
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
-			FormView(store: store.scope(state: \.form, action: /GearEditor.Action.InternalAction.form)) {
+			FormView(store: store.scope(state: \.form, action: \.internal.form)) {
 				Section(Strings.Editor.Fields.Details.title) {
 					TextField(
 						Strings.Editor.Fields.Details.name,
@@ -73,20 +75,24 @@ public struct GearEditorView: View {
 			}
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.navigationDestination(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GearEditor.Destination.State.bowlerPicker,
-			action: GearEditor.Destination.Action.bowlerPicker
-		) {
+		.bowlerPicker(store.scope(state: \.$destination.bowlerPicker, action: \.internal.destination.bowlerPicker))
+		.avatar(store.scope(state: \.$destination.avatar, action: \.internal.destination.avatar))
+	}
+}
+
+@MainActor extension View {
+	fileprivate func bowlerPicker(
+		_ store: PresentationStoreOf<ResourcePicker<Bowler.Summary, AlwaysEqual<Void>>>
+	) -> some View {
+		navigationDestination(store: store) {
 			ResourcePickerView(store: $0) { bowler in
 				Bowler.View(bowler)
 			}
 		}
-		.navigationDestination(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /GearEditor.Destination.State.avatar,
-			action: GearEditor.Destination.Action.avatar
-		) {
+	}
+
+	fileprivate func avatar(_ store: PresentationStoreOf<AvatarEditor>) -> some View {
+		navigationDestination(store: store) {
 			AvatarEditorView(store: $0)
 		}
 	}

--- a/ios/Approach/Sources/GearListFeature/GearFilter/GearFilter.swift
+++ b/ios/Approach/Sources/GearListFeature/GearFilter/GearFilter.swift
@@ -12,16 +12,16 @@ public struct GearFilter: Reducer {
 		@BindingState public var kind: Gear.Kind?
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didTapClearButton
 			case didTapApplyButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didChangeFilters(Gear.Kind?)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case `internal`(InternalAction)

--- a/ios/Approach/Sources/GearListFeature/GearFilter/GearFilter.swift
+++ b/ios/Approach/Sources/GearListFeature/GearFilter/GearFilter.swift
@@ -33,7 +33,7 @@ public struct GearFilter: Reducer {
 	@Dependency(\.dismiss) var dismiss
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/GearListFeature/GearList.swift
+++ b/ios/Approach/Sources/GearListFeature/GearList.swift
@@ -97,13 +97,13 @@ public struct GearList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.editor, action: /Action.editor) {
+			Scope(state: \.editor, action: \.editor) {
 				GearEditor()
 			}
-			Scope(state: /State.filters, action: /Action.filters) {
+			Scope(state: \.filters, action: \.filters) {
 				GearFilter()
 			}
-			Scope(state: /State.sortOrder, action: /Action.sortOrder) {
+			Scope(state: \.sortOrder, action: \.sortOrder) {
 				SortOrder()
 			}
 		}
@@ -122,11 +122,11 @@ public struct GearList: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			ResourceList {
 				gear.list(ownedBy: nil, ofKind: $0.kind, ordered: $0.sortOrder)
 			}
@@ -234,7 +234,7 @@ public struct GearList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/GearListFeature/GearList.swift
+++ b/ios/Approach/Sources/GearListFeature/GearList.swift
@@ -56,16 +56,16 @@ public struct GearList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapFilterButton
 			case didTapSortOrderButton
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didLoadEditableGear(TaskResult<Gear.Edit>)
-			case didDeleteGear(TaskResult<Gear.Summary>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didLoadEditableGear(Result<Gear.Edit, Error>)
+			case didDeleteGear(Result<Gear.Summary, Error>)
 
 			case list(ResourceList<Gear.Summary, Query>.Action)
 			case errors(Errors<ErrorID>.Action)
@@ -90,7 +90,7 @@ public struct GearList: Reducer {
 			case sortOrder(SortOrderLibrary.SortOrder<Gear.Ordering>.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case editor(GearEditor.Action)
 			case filters(GearFilter.Action)
 			case sortOrder(SortOrderLibrary.SortOrder<Gear.Ordering>.Action)
@@ -171,14 +171,14 @@ public struct GearList: Reducer {
 					switch delegateAction {
 					case let .didEdit(gear):
 						return .run { send in
-							await send(.internal(.didLoadEditableGear(TaskResult {
+							await send(.internal(.didLoadEditableGear(Result {
 								try await self.gear.edit(gear.id)
 							})))
 						}
 
 					case let .didDelete(gear):
 						return .run { send in
-							await send(.internal(.didDeleteGear(TaskResult {
+							await send(.internal(.didDeleteGear(Result {
 								try await self.gear.delete(gear.id)
 								return gear
 							})))

--- a/ios/Approach/Sources/ImportExportFeature/Export.swift
+++ b/ios/Approach/Sources/ImportExportFeature/Export.swift
@@ -26,15 +26,15 @@ public struct Export: Reducer {
 		public var shareUrl: URL { exportUrl ?? URL(string: "https://tryapproach.app")! }
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didFirstAppear
 			case didTapRetryButton
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didReceiveEvent(TaskResult<ExportService.Event>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didReceiveEvent(Result<ExportService.Event, Error>)
 		}
 
 		case view(ViewAction)

--- a/ios/Approach/Sources/LaneEditorFeature/LaneEditor.swift
+++ b/ios/Approach/Sources/LaneEditorFeature/LaneEditor.swift
@@ -27,22 +27,22 @@ public struct LaneEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didSwipe(SwipeAction)
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didDeleteLane
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)
 		case `internal`(InternalAction)
 	}
 
-	public enum SwipeAction: Equatable {
+	public enum SwipeAction {
 		case delete
 	}
 

--- a/ios/Approach/Sources/LaneEditorFeature/LaneEditor.swift
+++ b/ios/Approach/Sources/LaneEditorFeature/LaneEditor.swift
@@ -49,7 +49,7 @@ public struct LaneEditor: Reducer {
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { _, action in
 			switch action {

--- a/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
+++ b/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
@@ -117,7 +117,7 @@ public struct LeagueEditor: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
+		Scope(state: \.form, action: \.internal.form) {
 			LeagueForm()
 				.dependency(\.records, .init(
 					create: leagues.create,
@@ -218,7 +218,7 @@ public struct LeagueEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$alleyPicker, action: /Action.internal..Action.InternalAction.alleyPicker) {
+		.ifLet(\.$alleyPicker, action: \.internal.alleyPicker) {
 			ResourcePicker { _ in alleys.pickable() }
 		}
 

--- a/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
+++ b/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
@@ -115,7 +115,7 @@ public struct LeagueEditor: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
 			LeagueForm()

--- a/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
+++ b/ios/Approach/Sources/LeagueEditorFeature/LeagueEditor.swift
@@ -85,18 +85,18 @@ public struct LeagueEditor: Reducer {
 		public var id: Int { rawValue }
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapAlley
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didFinishCreating(League.Create)
 			case didFinishUpdating(League.Edit)
 			case didFinishArchiving(League.Edit)
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case setLocationSection(isShown: Bool)
 			case form(LeagueForm.Action)
 			case alleyPicker(PresentationAction<ResourcePicker<Alley.Summary, AlwaysEqual<Void>>.Action>)

--- a/ios/Approach/Sources/LeagueEditorFeature/LeagueEditorView.swift
+++ b/ios/Approach/Sources/LeagueEditorFeature/LeagueEditorView.swift
@@ -41,7 +41,7 @@ public struct LeagueEditorView: View {
 
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
-			FormView(store: store.scope(state: \.form, action: /LeagueEditor.Action.InternalAction.form)) {
+			FormView(store: store.scope(state: \.form, action: \.internal.form)) {
 				detailsSection(viewStore)
 				recurrenceSection(viewStore)
 				locationSection(viewStore)
@@ -53,7 +53,7 @@ public struct LeagueEditorView: View {
 			.onAppear { viewStore.send(.onAppear) }
 		})
 		.navigationDestination(
-			store: store.scope(state: \.$alleyPicker, action: { .internal(.alleyPicker($0)) })
+			store: store.scope(state: \.$alleyPicker, action: \.internal.alleyPicker)
 		) { store in
 			ResourcePickerView(store: store) { alley in
 				Alley.View(alley)

--- a/ios/Approach/Sources/LeaguesListFeature/LeaguesFilter/LeaguesFilter.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/LeaguesFilter/LeaguesFilter.swift
@@ -33,7 +33,7 @@ public struct LeaguesFilter: Reducer {
 	@Dependency(\.dismiss) var dismiss
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/LeaguesListFeature/LeaguesFilter/LeaguesFilter.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/LeaguesFilter/LeaguesFilter.swift
@@ -12,16 +12,16 @@ public struct LeaguesFilter: Reducer {
 		@BindingState public var recurrence: League.Recurrence?
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didTapClearButton
 			case didTapApplyButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didChangeFilters(League.Recurrence?)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case `internal`(InternalAction)

--- a/ios/Approach/Sources/LeaguesListFeature/LeaguesList.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/LeaguesList.swift
@@ -126,16 +126,16 @@ public struct LeaguesList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.editor, action: /Action.editor) {
+			Scope(state: \.editor, action: \.editor) {
 				LeagueEditor()
 			}
-			Scope(state: /State.filters, action: /Action.filters) {
+			Scope(state: \.filters, action: \.filters) {
 				LeaguesFilter()
 			}
-			Scope(state: /State.series, action: /Action.series) {
+			Scope(state: \.series, action: \.series) {
 				SeriesList()
 			}
-			Scope(state: /State.sortOrder, action: /Action.sortOrder) {
+			Scope(state: \.sortOrder, action: \.sortOrder) {
 				SortOrder()
 			}
 		}
@@ -159,11 +159,11 @@ public struct LeaguesList: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			ResourceList { request in
 				leagues.list(
 					bowledBy: request.filter.bowler,
@@ -173,11 +173,11 @@ public struct LeaguesList: Reducer {
 			}
 		}
 
-		Scope(state: \.preferredGear, action: /Action.internal..Action.InternalAction.preferredGear) {
+		Scope(state: \.preferredGear, action: \.internal.preferredGear) {
 			PreferredGear()
 		}
 
-		Scope(state: \.widgets, action: /Action.internal..Action.InternalAction.widgets) {
+		Scope(state: \.widgets, action: \.internal.widgets) {
 			StatisticsWidgetLayout()
 		}
 
@@ -331,7 +331,7 @@ public struct LeaguesList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/LeaguesListFeature/LeaguesList.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/LeaguesList.swift
@@ -80,8 +80,8 @@ public struct LeaguesList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didStartTask
 			case didTapLeague(id: League.ID)
@@ -89,12 +89,12 @@ public struct LeaguesList: Reducer {
 			case didTapSortOrderButton
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 
-		public enum InternalAction: Equatable {
-			case didLoadEditableLeague(TaskResult<League.Edit>)
-			case didArchiveLeague(TaskResult<League.List>)
-			case didLoadSeriesLeague(TaskResult<League.SeriesHost>)
+		@CasePathable public enum InternalAction {
+			case didLoadEditableLeague(Result<League.Edit, Error>)
+			case didArchiveLeague(Result<League.List, Error>)
+			case didLoadSeriesLeague(Result<League.SeriesHost, Error>)
 			case didSetIsShowingWidgets(Bool)
 
 			case errors(Errors<ErrorID>.Action)
@@ -118,7 +118,7 @@ public struct LeaguesList: Reducer {
 			case sortOrder(SortOrder<League.Ordering>.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case editor(LeagueEditor.Action)
 			case filters(LeaguesFilter.Action)
 			case series(SeriesList.Action)
@@ -207,7 +207,7 @@ public struct LeaguesList: Reducer {
 
 				case let .didTapLeague(id):
 					return .run { send in
-						await send(.internal(.didLoadSeriesLeague(TaskResult {
+						await send(.internal(.didLoadSeriesLeague(Result {
 							try await leagues.seriesHost(id)
 						})))
 					}
@@ -263,14 +263,14 @@ public struct LeaguesList: Reducer {
 					switch delegateAction {
 					case let .didEdit(league):
 						return .run { send in
-							await send(.internal(.didLoadEditableLeague(TaskResult {
+							await send(.internal(.didLoadEditableLeague(Result {
 								try await leagues.edit(league.id)
 							})))
 						}
 
 					case let .didArchive(league):
 						return .run { send in
-							await send(.internal(.didArchiveLeague(TaskResult {
+							await send(.internal(.didArchiveLeague(Result {
 								try await leagues.archive(league.id)
 								return league
 							})))

--- a/ios/Approach/Sources/LeaguesListFeature/LeaguesListView.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/LeaguesListView.swift
@@ -1,6 +1,7 @@
 import AssetsLibrary
 import ComposableArchitecture
 import ErrorsFeature
+import ExtensionsLibrary
 import LeagueEditorFeature
 import ModelsLibrary
 import ResourceListLibrary
@@ -34,7 +35,7 @@ public struct LeaguesListView: View {
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			ResourceListView(
-				store: store.scope(state: \.list, action: /LeaguesList.Action.InternalAction.list)
+				store: store.scope(state: \.list, action: \.internal.list)
 			) { league in
 				Button { viewStore.send(.didTapLeague(id: league.id)) } label: {
 					LabeledContent(league.name, value: format(average: league.average))
@@ -43,7 +44,7 @@ public struct LeaguesListView: View {
 			} header: {
 				if viewStore.isShowingWidgets {
 					Section {
-						StatisticsWidgetLayoutView(store: store.scope(state: \.widgets, action: { .internal(.widgets($0)) }))
+						StatisticsWidgetLayoutView(store: store.scope(state: \.widgets, action: \.internal.widgets))
 					}
 					.listRowSeparator(.hidden)
 					.listRowInsets(EdgeInsets())
@@ -51,7 +52,7 @@ public struct LeaguesListView: View {
 				}
 			} footer: {
 				PreferredGearView(
-					store: store.scope(state: \.preferredGear, action: /LeaguesList.Action.InternalAction.preferredGear)
+					store: store.scope(state: \.preferredGear, action: \.internal.preferredGear)
 				)
 			}
 			.navigationTitle(viewStore.bowlerName)
@@ -68,36 +69,25 @@ public struct LeaguesListView: View {
 			.task { viewStore.send(.didStartTask) }
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.leagueEditor(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.leaguesFilter(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.sortOrder(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.seriesList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.leagueEditor(store.scope(state: \.$destination.editor, action: \.internal.destination.editor))
+		.leaguesFilter(store.scope(state: \.$destination.filters, action: \.internal.destination.filters))
+		.sortOrder(store.scope(state: \.$destination.sortOrder, action: \.internal.destination.sortOrder))
+		.seriesList(store.scope(state: \.$destination.series, action: \.internal.destination.series))
 	}
 }
 
 @MainActor extension View {
-	fileprivate typealias State = PresentationState<LeaguesList.Destination.State>
-	fileprivate typealias Action = PresentationAction<LeaguesList.Destination.Action>
-
-	fileprivate func leagueEditor(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /LeaguesList.Destination.State.editor,
-			action: LeaguesList.Destination.Action.editor
-		) { (store: StoreOf<LeagueEditor>) in
+	fileprivate func leagueEditor(_ store: PresentationStoreOf<LeagueEditor>) -> some View {
+		sheet(store: store) { (store: StoreOf<LeagueEditor>) in
 			NavigationStack {
 				LeagueEditorView(store: store)
 			}
 		}
 	}
 
-	fileprivate func leaguesFilter(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /LeaguesList.Destination.State.filters,
-			action: LeaguesList.Destination.Action.filters
-		) { (store: StoreOf<LeaguesFilter>) in
+	fileprivate func leaguesFilter(_ store: PresentationStoreOf<LeaguesFilter>) -> some View {
+		sheet(store: store) { (store: StoreOf<LeaguesFilter>) in
 			NavigationStack {
 				LeaguesFilterView(store: store)
 			}
@@ -105,12 +95,8 @@ public struct LeaguesListView: View {
 		}
 	}
 
-	fileprivate func sortOrder(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /LeaguesList.Destination.State.sortOrder,
-			action: LeaguesList.Destination.Action.sortOrder
-		) { (store: StoreOf<SortOrderLibrary.SortOrder<League.Ordering>>) in
+	fileprivate func sortOrder(_ store: PresentationStoreOf<SortOrderLibrary.SortOrder<League.Ordering>>) -> some View {
+		sheet(store: store) { (store: StoreOf<SortOrderLibrary.SortOrder<League.Ordering>>) in
 			NavigationStack {
 				SortOrderView(store: store)
 			}
@@ -118,12 +104,8 @@ public struct LeaguesListView: View {
 		}
 	}
 
-	fileprivate func seriesList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /LeaguesList.Destination.State.series,
-			action: LeaguesList.Destination.Action.series
-		) { (store: StoreOf<SeriesList>) in
+	fileprivate func seriesList(_ store: PresentationStoreOf<SeriesList>) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<SeriesList>) in
 			SeriesListView(store: store)
 		}
 	}

--- a/ios/Approach/Sources/LeaguesListFeature/PreferredGear/PreferredGear.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/PreferredGear/PreferredGear.swift
@@ -18,18 +18,18 @@ public struct PreferredGear: Reducer {
 		@PresentationState var gearPicker: ResourcePicker<Gear.Summary, Bowler.ID>.State?
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didFirstAppear
 			case didTapManageButton
 		}
-		public enum DelegateAction: Equatable {
-			case errorLoadingGear(TaskResult<Never>)
-			case errorUpdatingPreferredGear(TaskResult<Never>)
+		@CasePathable public enum DelegateAction {
+			case errorLoadingGear(Result<Never, Error>)
+			case errorUpdatingPreferredGear(Result<Never, Error>)
 		}
-		public enum InternalAction: Equatable {
-			case didLoadGear(TaskResult<[Gear.Summary]>)
-			case didUpdatePreferredGear(TaskResult<[Gear.Summary]>)
+		@CasePathable public enum InternalAction {
+			case didLoadGear(Result<[Gear.Summary], Error>)
+			case didUpdatePreferredGear(Result<[Gear.Summary], Error>)
 			case gearPicker(PresentationAction<ResourcePicker<Gear.Summary, Bowler.ID>.Action>)
 		}
 
@@ -50,7 +50,7 @@ public struct PreferredGear: Reducer {
 				switch viewAction {
 				case .didFirstAppear:
 					return .run { [bowler = state.bowler] send in
-						await send(.internal(.didLoadGear(TaskResult {
+						await send(.internal(.didLoadGear(Result {
 							try await gear.preferredGear(forBowler: bowler)
 						})))
 					}
@@ -85,7 +85,7 @@ public struct PreferredGear: Reducer {
 					case let .didChangeSelection(gear):
 						state.gear = .init(uniqueElements: gear)
 						return .run { [gear = state.gear, bowler = state.bowler] send in
-							await send(.internal(.didUpdatePreferredGear(TaskResult {
+							await send(.internal(.didUpdatePreferredGear(Result {
 								try await self.gear.updatePreferredGear(gear.map(\.id), forBowler: bowler)
 								return Array(gear)
 							})))

--- a/ios/Approach/Sources/LeaguesListFeature/PreferredGear/PreferredGear.swift
+++ b/ios/Approach/Sources/LeaguesListFeature/PreferredGear/PreferredGear.swift
@@ -100,7 +100,7 @@ public struct PreferredGear: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$gearPicker, action: /Action.internal..Action.InternalAction.gearPicker) {
+		.ifLet(\.$gearPicker, action: \.internal.gearPicker) {
 			ResourcePicker { _ in gear.list(ordered: .byName) }
 		}
 	}
@@ -143,7 +143,7 @@ public struct PreferredGearView: View {
 			.onFirstAppear { viewStore.send(.didFirstAppear) }
 		})
 		.navigationDestination(
-			store: store.scope(state: \.$gearPicker, action: { .internal(.gearPicker($0)) })
+			store: store.scope(state: \.$gearPicker, action: \.internal.gearPicker)
 		) { store in
 			ResourcePickerView(store: store) {
 				Gear.ViewWithAvatar($0)

--- a/ios/Approach/Sources/OnboardingFeature/Onboarding.swift
+++ b/ios/Approach/Sources/OnboardingFeature/Onboarding.swift
@@ -89,7 +89,7 @@ public struct Onboarding: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/OnboardingFeature/Onboarding.swift
+++ b/ios/Approach/Sources/OnboardingFeature/Onboarding.swift
@@ -17,20 +17,20 @@ public struct Onboarding: Reducer {
 		public init() {}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didFirstAppear
 			case didTapGetStarted
 			case didTapAddBowler
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didFinishOnboarding
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case nextStep
-			case didCreateBowler(TaskResult<Never>)
+			case didCreateBowler(Result<Never, Error>)
 		}
 
 		case view(ViewAction)

--- a/ios/Approach/Sources/OpponentDetailsFeature/OpponentDetails.swift
+++ b/ios/Approach/Sources/OpponentDetailsFeature/OpponentDetails.swift
@@ -24,14 +24,14 @@ public struct OpponentDetails: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didFirstAppear
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didLoadDetails(TaskResult<Bowler.OpponentDetails>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didLoadDetails(Result<Bowler.OpponentDetails, Error>)
 			case errors(Errors<ErrorID>.Action)
 		}
 
@@ -96,7 +96,7 @@ public struct OpponentDetails: Reducer {
 
 	private func refreshDetails(forOpponent: Bowler.ID) -> Effect<Action> {
 		.run { send in
-			await send(.internal(.didLoadDetails(TaskResult {
+			await send(.internal(.didLoadDetails(Result {
 				try await bowlers.record(againstOpponent: forOpponent)
 			})))
 		}

--- a/ios/Approach/Sources/OpponentDetailsFeature/OpponentDetails.swift
+++ b/ios/Approach/Sources/OpponentDetailsFeature/OpponentDetails.swift
@@ -48,7 +48,7 @@ public struct OpponentDetails: Reducer {
 	@Dependency(\.bowlers) var bowlers
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 

--- a/ios/Approach/Sources/OpponentDetailsFeature/OpponentDetailsView.swift
+++ b/ios/Approach/Sources/OpponentDetailsFeature/OpponentDetailsView.swift
@@ -53,7 +53,7 @@ public struct OpponentDetailsView: View {
 			.onFirstAppear { viewStore.send(.didFirstAppear) }
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 	}
 }
 

--- a/ios/Approach/Sources/OpponentsListFeature/OpponentsList.swift
+++ b/ios/Approach/Sources/OpponentsListFeature/OpponentsList.swift
@@ -59,16 +59,16 @@ public struct OpponentsList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapSortOrderButton
 			case didTapOpponent(Bowler.ID)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didLoadEditableOpponent(TaskResult<Bowler.Edit>)
-			case didArchiveOpponent(TaskResult<Bowler.Opponent>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didLoadEditableOpponent(Result<Bowler.Edit, Error>)
+			case didArchiveOpponent(Result<Bowler.Opponent, Error>)
 
 			case list(ResourceList<Bowler.Opponent, Bowler.Ordering>.Action)
 			case errors(Errors<ErrorID>.Action)
@@ -88,7 +88,7 @@ public struct OpponentsList: Reducer {
 			case sortOrder(SortOrder<Bowler.Ordering>.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case details(OpponentDetails.Action)
 			case editor(BowlerEditor.Action)
 			case sortOrder(SortOrder<Bowler.Ordering>.Action)
@@ -168,14 +168,14 @@ public struct OpponentsList: Reducer {
 					switch delegateAction {
 					case let .didEdit(opponent):
 						return .run { send in
-							await send(.internal(.didLoadEditableOpponent(TaskResult {
+							await send(.internal(.didLoadEditableOpponent(Result {
 								try await bowlers.edit(opponent.id)
 							})))
 						}
 
 					case let .didArchive(bowler):
 						return .run { send in
-							await send(.internal(.didArchiveOpponent(TaskResult {
+							await send(.internal(.didArchiveOpponent(Result {
 								try await bowlers.archive(bowler.id)
 								return bowler
 							})))

--- a/ios/Approach/Sources/OpponentsListFeature/OpponentsList.swift
+++ b/ios/Approach/Sources/OpponentsListFeature/OpponentsList.swift
@@ -95,13 +95,13 @@ public struct OpponentsList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.details, action: /Action.details) {
+			Scope(state: \.details, action: \.details) {
 				OpponentDetails()
 			}
-			Scope(state: /State.editor, action: /Action.editor) {
+			Scope(state: \.editor, action: \.editor) {
 				BowlerEditor()
 			}
-			Scope(state: /State.sortOrder, action: /Action.sortOrder) {
+			Scope(state: \.sortOrder, action: \.sortOrder) {
 				SortOrder()
 			}
 		}
@@ -120,11 +120,11 @@ public struct OpponentsList: Reducer {
 	@Dependency(\.recentlyUsed) var recentlyUsed
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			ResourceList(fetchResources: bowlers.opponents(ordering:))
 		}
 
@@ -226,7 +226,7 @@ public struct OpponentsList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/OpponentsListFeature/OpponentsListView.swift
+++ b/ios/Approach/Sources/OpponentsListFeature/OpponentsListView.swift
@@ -2,6 +2,7 @@ import AssetsLibrary
 import BowlerEditorFeature
 import ComposableArchitecture
 import ErrorsFeature
+import ExtensionsLibrary
 import FeatureActionLibrary
 import ModelsLibrary
 import ModelsViewsLibrary
@@ -31,7 +32,7 @@ public struct OpponentsListView: View {
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			ResourceListView(
-				store: store.scope(state: \.list, action: /OpponentsList.Action.InternalAction.list)
+				store: store.scope(state: \.list, action: \.internal.list)
 			) { opponent in
 				if viewStore.isOpponentDetailsEnabled {
 					Button { store.send(.view(.didTapOpponent(opponent.id))) } label: {
@@ -54,28 +55,30 @@ public struct OpponentsListView: View {
 				SortButton(isActive: false) { store.send(.view(.didTapSortOrderButton)) }
 			}
 		}
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.navigationDestination(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /OpponentsList.Destination.State.details,
-			action: OpponentsList.Destination.Action.details
-		) { (store: StoreOf<OpponentDetails>) in
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.opponentDetails(store.scope(state: \.$destination.details, action: \.internal.destination.details))
+		.opponentEditor(store.scope(state: \.$destination.editor, action: \.internal.destination.editor))
+		.sortOrder(store.scope(state: \.$destination.sortOrder, action: \.internal.destination.sortOrder))
+	}
+}
+
+@MainActor extension View {
+	fileprivate func opponentDetails(_ store: PresentationStoreOf<OpponentDetails>) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<OpponentDetails>) in
 			OpponentDetailsView(store: store)
 		}
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /OpponentsList.Destination.State.editor,
-			action: OpponentsList.Destination.Action.editor
-		) { (store: StoreOf<BowlerEditor>) in
+	}
+
+	fileprivate func opponentEditor(_ store: PresentationStoreOf<BowlerEditor>) -> some View {
+		sheet(store: store) { (store: StoreOf<BowlerEditor>) in
 			NavigationStack {
 				BowlerEditorView(store: store)
 			}
 		}
-		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /OpponentsList.Destination.State.sortOrder,
-			action: OpponentsList.Destination.Action.sortOrder
-		) { store in
+	}
+
+	fileprivate func sortOrder(_ store: PresentationStoreOf<SortOrderLibrary.SortOrder<Bowler.Ordering>>) -> some View {
+		sheet(store: store) { store in
 			NavigationStack {
 				SortOrderView(store: store)
 			}

--- a/ios/Approach/Sources/PaywallFeature/Paywall.swift
+++ b/ios/Approach/Sources/PaywallFeature/Paywall.swift
@@ -26,17 +26,17 @@ public struct Paywall: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didStartTask
 			case didTapRestorePurchasesButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case setProductAvailability(Bool)
-			case didFinishRestoringPurchases(TaskResult<Bool>)
+			case didFinishRestoringPurchases(Result<Bool, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 		}

--- a/ios/Approach/Sources/PaywallFeature/Paywall.swift
+++ b/ios/Approach/Sources/PaywallFeature/Paywall.swift
@@ -58,7 +58,7 @@ public struct Paywall: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 

--- a/ios/Approach/Sources/PaywallFeature/Paywall.swift
+++ b/ios/Approach/Sources/PaywallFeature/Paywall.swift
@@ -56,7 +56,7 @@ public struct Paywall: Reducer {
 	@Dependency(\.products) var products
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
 			Errors()

--- a/ios/Approach/Sources/ReorderingLibrary/Reorderable.swift
+++ b/ios/Approach/Sources/ReorderingLibrary/Reorderable.swift
@@ -14,16 +14,16 @@ public struct Reorderable<Content: View, Item: Identifiable & Equatable>: Reduce
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didMoveItem(from: IndexSet, to: Int)
 			case didFinishReordering
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case itemDidMove(from: IndexSet, to: Int)
 			case didFinishReordering
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceList+EmptyContent.swift
+++ b/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceList+EmptyContent.swift
@@ -57,12 +57,12 @@ public struct ResourceListEmpty: Reducer {
 		)
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didTapActionButton
 		}
-		public enum InternalAction: Equatable { case doNothing }
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum InternalAction { case doNothing }
+		@CasePathable public enum DelegateAction {
 			case didTapActionButton
 		}
 

--- a/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceList.swift
+++ b/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceList.swift
@@ -40,10 +40,10 @@ public struct ResourceList<
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable { case doNothing }
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction { case doNothing }
 
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didDelete(R)
 			case didArchive(R)
 			case didEdit(R)
@@ -53,7 +53,7 @@ public struct ResourceList<
 			case didTapEmptyStateButton
 		}
 
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case sectionList(SectionResourceList<R, Q>.Action)
 		}
 

--- a/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceList.swift
+++ b/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceList.swift
@@ -69,7 +69,7 @@ public struct ResourceList<
 	let fetchResources: (Q) -> AsyncThrowingStream<[R], Swift.Error>
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.sectionList, action: /Action.internal..Action.InternalAction.sectionList) {
+		Scope(state: \.sectionList, action: \.internal.sectionList) {
 			SectionResourceList(fetchSections: fetchResources(query:))
 		}
 

--- a/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceListView.swift
+++ b/ios/Approach/Sources/ResourceListLibrary/ResourceList/ResourceListView.swift
@@ -55,7 +55,7 @@ public struct ResourceListView<
 
 	public var body: some View {
 		SectionResourceListView(
-			store: store.scope(state: \.sectionList, action: { .internal(.sectionList($0)) }),
+			store: store.scope(state: \.sectionList, action: \.internal.sectionList),
 			row: { _, element in row(element) },
 			header: header,
 			footer: footer

--- a/ios/Approach/Sources/ResourceListLibrary/SectionResourceList/SectionResourceList.swift
+++ b/ios/Approach/Sources/ResourceListLibrary/SectionResourceList/SectionResourceList.swift
@@ -128,7 +128,7 @@ public struct SectionResourceList<
 	let fetchSections: (Q) -> AsyncThrowingStream<[Section], Swift.Error>
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.emptyState, action: /Action.internal..Action.InternalAction.empty) {
+		Scope(state: \.emptyState, action: \.internal.empty) {
 			ResourceListEmpty()
 		}
 
@@ -257,7 +257,7 @@ public struct SectionResourceList<
 			case .delegate:
 				return .none
 			}
-		}.ifLet(\.errorState, action: /Action.internal..Action.InternalAction.error) {
+		}.ifLet(\.errorState, action: \.internal.error) {
 			ResourceListEmpty()
 		}
 	}

--- a/ios/Approach/Sources/ResourceListLibrary/SectionResourceList/SectionResourceList.swift
+++ b/ios/Approach/Sources/ResourceListLibrary/SectionResourceList/SectionResourceList.swift
@@ -69,8 +69,8 @@ public struct SectionResourceList<
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case task
 			case didFirstAppear
 			case didTapAddButton
@@ -82,7 +82,7 @@ public struct SectionResourceList<
 			case binding(BindingAction<State>)
 		}
 
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didDelete(R)
 			case didArchive(R)
 			case didEdit(R)
@@ -92,9 +92,9 @@ public struct SectionResourceList<
 			case didTapEmptyStateButton
 		}
 
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case refreshObservation
-			case sectionsResponse(TaskResult<[Section]>)
+			case sectionsResponse(Result<[Section], Error>)
 			case empty(ResourceListEmpty.Action)
 			case error(ResourceListEmpty.Action)
 		}
@@ -113,7 +113,7 @@ public struct SectionResourceList<
 		case add
 	}
 
-	public enum SwipeAction: Equatable {
+	public enum SwipeAction {
 		case edit
 		case delete
 		case archive

--- a/ios/Approach/Sources/ResourcePickerLibrary/ResourcePicker.swift
+++ b/ios/Approach/Sources/ResourcePickerLibrary/ResourcePicker.swift
@@ -38,8 +38,8 @@ public struct ResourcePicker<Resource: PickableResource, Query: Equatable>: Redu
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case task
 			case didFirstAppear
 			case didTapCancelButton
@@ -47,12 +47,12 @@ public struct ResourcePicker<Resource: PickableResource, Query: Equatable>: Redu
 			case didTapResource(Resource)
 			case didTapDeselectAllButton
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didChangeSelection([Resource])
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case refreshObservation
-			case didLoadResources(TaskResult<[Resource]>)
+			case didLoadResources(Result<[Resource], Error>)
 		}
 
 		case view(ViewAction)

--- a/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
@@ -56,18 +56,18 @@ public struct SeriesEditor: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didTapAlley
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didFinishCreating(Series.Create)
 			case didFinishArchiving(Series.Edit)
 			case didFinishUpdating(Series.Edit)
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case form(SeriesForm.Action)
 			case alleyPicker(PresentationAction<ResourcePicker<Alley.Summary, AlwaysEqual<Void>>.Action>)
 		}

--- a/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
@@ -94,7 +94,7 @@ public struct SeriesEditor: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
+		Scope(state: \.form, action: \.internal.form) {
 			SeriesForm()
 				.dependency(\.records, .init(
 					create: series.create,
@@ -207,7 +207,7 @@ public struct SeriesEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$alleyPicker, action: /Action.internal..Action.InternalAction.alleyPicker) {
+		.ifLet(\.$alleyPicker, action: \.internal.alleyPicker) {
 			ResourcePicker { _ in
 				alleys.pickable()
 			}

--- a/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/SeriesEditor.swift
@@ -92,7 +92,7 @@ public struct SeriesEditor: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.form, action: /Action.internal..Action.InternalAction.form) {
 			SeriesForm()

--- a/ios/Approach/Sources/SeriesEditorFeature/SeriesEditorView.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/SeriesEditorView.swift
@@ -34,7 +34,7 @@ public struct SeriesEditorView: View {
 
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
-			FormView(store: store.scope(state: \.form, action: /SeriesEditor.Action.InternalAction.form)) {
+			FormView(store: store.scope(state: \.form, action: \.internal.form)) {
 				Section(Strings.Editor.Fields.Details.title) {
 					Stepper(
 						Strings.Series.Editor.Fields.numberOfGames(viewStore.numberOfGames),
@@ -87,7 +87,7 @@ public struct SeriesEditorView: View {
 			.onAppear { viewStore.send(.onAppear) }
 		})
 		.navigationDestination(
-			store: store.scope(state: \.$alleyPicker, action: { .internal(.alleyPicker($0)) })
+			store: store.scope(state: \.$alleyPicker, action: \.internal.alleyPicker)
 		) { store in
 			ResourcePickerView(store: store) { alley in
 				Alley.View(alley)

--- a/ios/Approach/Sources/SeriesListFeature/SeriesList.swift
+++ b/ios/Approach/Sources/SeriesListFeature/SeriesList.swift
@@ -124,16 +124,16 @@ public struct SeriesList: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.leagueEditor, action: /Action.leagueEditor) {
+			Scope(state: \.leagueEditor, action: \.leagueEditor) {
 				LeagueEditor()
 			}
-			Scope(state: /State.seriesEditor, action: /Action.seriesEditor) {
+			Scope(state: \.seriesEditor, action: \.seriesEditor) {
 				SeriesEditor()
 			}
-			Scope(state: /State.games, action: /Action.games) {
+			Scope(state: \.games, action: \.games) {
 				GamesList()
 			}
-			Scope(state: /State.sortOrder, action: /Action.sortOrder) {
+			Scope(state: \.sortOrder, action: \.sortOrder) {
 				SortOrder()
 			}
 		}
@@ -150,11 +150,11 @@ public struct SeriesList: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			SectionResourceList(fetchSections: self.fetchResources(query:))
 		}
 
@@ -305,7 +305,7 @@ public struct SeriesList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/SeriesListFeature/SeriesList.swift
+++ b/ios/Approach/Sources/SeriesListFeature/SeriesList.swift
@@ -70,18 +70,18 @@ public struct SeriesList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapEditButton
 			case didTapSortOrderButton
 			case didTapSeries(Series.ID)
 		}
 
-		public enum InternalAction: Equatable {
-			case didArchiveSeries(TaskResult<Series.List>)
-			case didLoadEditableSeries(TaskResult<Series.Edit>)
-			case didLoadEditableLeague(TaskResult<League.Edit>)
+		@CasePathable public enum InternalAction {
+			case didArchiveSeries(Result<Series.List, Error>)
+			case didLoadEditableSeries(Result<Series.Edit, Error>)
+			case didLoadEditableLeague(Result<League.Edit, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 			case destination(PresentationAction<Destination.Action>)
@@ -89,7 +89,7 @@ public struct SeriesList: Reducer {
 				.FetchRequest>.Action)
 		}
 
-		public enum DelegateAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
 
 		case view(ViewAction)
 		case `internal`(InternalAction)
@@ -116,7 +116,7 @@ public struct SeriesList: Reducer {
 			case sortOrder(SortOrderLibrary.SortOrder<Series.Ordering>.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case seriesEditor(SeriesEditor.Action)
 			case leagueEditor(LeagueEditor.Action)
 			case games(GamesList.Action)
@@ -173,7 +173,7 @@ public struct SeriesList: Reducer {
 
 				case .didTapEditButton:
 					return .run { [id = state.league.id] send in
-						await send(.internal(.didLoadEditableLeague(TaskResult {
+						await send(.internal(.didLoadEditableLeague(Result {
 							try await leagues.edit(id)
 						})))
 					}
@@ -226,14 +226,14 @@ public struct SeriesList: Reducer {
 					switch delegateAction {
 					case let .didEdit(series):
 						return .run { send in
-							await send(.internal(.didLoadEditableSeries(TaskResult {
+							await send(.internal(.didLoadEditableSeries(Result {
 								try await self.series.edit(series.id)
 							})))
 						}
 
 					case let .didArchive(series):
 						return .run { send in
-							await send(.internal(.didArchiveSeries(TaskResult {
+							await send(.internal(.didArchiveSeries(Result {
 								try await self.series.archive(series.id)
 								return series
 							})))

--- a/ios/Approach/Sources/SeriesListFeature/SeriesListView.swift
+++ b/ios/Approach/Sources/SeriesListFeature/SeriesListView.swift
@@ -2,6 +2,7 @@ import AssetsLibrary
 import ComposableArchitecture
 import DateTimeLibrary
 import ErrorsFeature
+import ExtensionsLibrary
 import GamesListFeature
 import LeagueEditorFeature
 import ModelsLibrary
@@ -33,7 +34,7 @@ public struct SeriesListView: View {
 	public var body: some View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			SectionResourceListView(
-				store: store.scope(state: \.list, action: /SeriesList.Action.InternalAction.list)
+				store: store.scope(state: \.list, action: \.internal.list)
 			) { _, series in
 				Button { viewStore.send(.didTapSeries(series.id)) } label: {
 					SeriesListItem(series: series)
@@ -56,48 +57,33 @@ public struct SeriesListView: View {
 			}
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.seriesEditor(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.leagueEditor(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.sortOrder(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.gamesList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.seriesEditor(store.scope(state: \.$destination.seriesEditor, action: \.internal.destination.seriesEditor))
+		.leagueEditor(store.scope(state: \.$destination.leagueEditor, action: \.internal.destination.leagueEditor))
+		.sortOrder(store.scope(state: \.$destination.sortOrder, action: \.internal.destination.sortOrder))
+		.gamesList(store.scope(state: \.$destination.games, action: \.internal.destination.games))
 	}
 }
 
 @MainActor extension View {
-	fileprivate typealias State = PresentationState<SeriesList.Destination.State>
-	fileprivate typealias Action = PresentationAction<SeriesList.Destination.Action>
-
-	fileprivate func seriesEditor(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /SeriesList.Destination.State.seriesEditor,
-			action: SeriesList.Destination.Action.seriesEditor
-		) { (store: StoreOf<SeriesEditor>) in
+	fileprivate func seriesEditor(_ store: PresentationStoreOf<SeriesEditor>) -> some View {
+		sheet(store: store) { (store: StoreOf<SeriesEditor>) in
 			NavigationStack {
 				SeriesEditorView(store: store)
 			}
 		}
 	}
 
-	fileprivate func leagueEditor(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /SeriesList.Destination.State.leagueEditor,
-			action: SeriesList.Destination.Action.leagueEditor
-		) { (store: StoreOf<LeagueEditor>) in
+	fileprivate func leagueEditor(_ store: PresentationStoreOf<LeagueEditor>) -> some View {
+		sheet(store: store) { (store: StoreOf<LeagueEditor>) in
 			NavigationStack {
 				LeagueEditorView(store: store)
 			}
 		}
 	}
 
-	fileprivate func sortOrder(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /SeriesList.Destination.State.sortOrder,
-			action: SeriesList.Destination.Action.sortOrder
-		) { (store: StoreOf<SortOrderLibrary.SortOrder<Series.Ordering>>) in
+	fileprivate func sortOrder(_ store: PresentationStoreOf<SortOrderLibrary.SortOrder<Series.Ordering>>) -> some View {
+		sheet(store: store) { (store: StoreOf<SortOrderLibrary.SortOrder<Series.Ordering>>) in
 			NavigationStack {
 				SortOrderView(store: store)
 			}
@@ -105,12 +91,8 @@ public struct SeriesListView: View {
 		}
 	}
 
-	fileprivate func gamesList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /SeriesList.Destination.State.games,
-			action: SeriesList.Destination.Action.games
-		) { (store: StoreOf<GamesList>) in
+	fileprivate func gamesList(_ store: PresentationStoreOf<GamesList>) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<GamesList>) in
 			GamesListView(store: store)
 		}
 	}

--- a/ios/Approach/Sources/SettingsFeature/Analytics/AnalyticsSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Analytics/AnalyticsSettings.swift
@@ -22,13 +22,13 @@ public struct AnalyticsSettings: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case updatedOptInStatus(Analytics.OptInStatus)
 		}
 

--- a/ios/Approach/Sources/SettingsFeature/Analytics/AnalyticsSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Analytics/AnalyticsSettings.swift
@@ -42,7 +42,7 @@ public struct AnalyticsSettings: Reducer {
 	@Dependency(\.analytics) var analytics
 
 	public var body: some Reducer<State, Action> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce { state, action in
 			switch action {

--- a/ios/Approach/Sources/SettingsFeature/AppIcon/AppIconList+Extensions.swift
+++ b/ios/Approach/Sources/SettingsFeature/AppIcon/AppIconList+Extensions.swift
@@ -6,7 +6,7 @@ import UIKit
 extension AppIconList {
 	func fetchCurrentAppIcon() -> Effect<Action> {
 		.run { send in
-			await send(.internal(.didFetchIcon(TaskResult { AppIcon(rawValue: await appIcon.getAppIconName() ?? "") })))
+			await send(.internal(.didFetchIcon(Result { AppIcon(rawValue: await appIcon.getAppIconName() ?? "") })))
 		}
 	}
 }

--- a/ios/Approach/Sources/SettingsFeature/AppIcon/AppIconList.swift
+++ b/ios/Approach/Sources/SettingsFeature/AppIcon/AppIconList.swift
@@ -28,17 +28,17 @@ public struct AppIconList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didFirstAppear
 			case didTapIcon(AppIcon)
 			case didTapReset
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didUpdateIcon(TaskResult<Never>)
-			case didFetchIcon(TaskResult<AppIcon?>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didUpdateIcon(Result<Never, Error>)
+			case didFetchIcon(Result<AppIcon?, Error>)
 			case alert(PresentationAction<Alert>)
 		}
 		public enum Alert: Equatable {}

--- a/ios/Approach/Sources/SettingsFeature/AppIcon/AppIconList.swift
+++ b/ios/Approach/Sources/SettingsFeature/AppIcon/AppIconList.swift
@@ -113,7 +113,7 @@ public struct AppIconList: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$alert, action: /Action.internal..Action.InternalAction.alert)
+		.ifLet(\.$alert, action: \.internal.alert)
 
 		AnalyticsReducer<State, Action> { _, action in
 			switch action {
@@ -165,7 +165,7 @@ public struct AppIconListView: View {
 			.navigationTitle(Strings.Settings.AppIcon.title)
 			.onFirstAppear { viewStore.send(.didFirstAppear) }
 			.onAppear { viewStore.send(.onAppear) }
-			.alert(store: self.store.scope(state: \.$alert, action: { .internal(.alert($0)) }))
+			.alert(store: self.store.scope(state: \.$alert, action: \.internal.alert))
 		})
 	}
 }

--- a/ios/Approach/Sources/SettingsFeature/Help/HelpSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Help/HelpSettings.swift
@@ -66,10 +66,10 @@ public struct HelpSettings: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.analytics, action: /Action.analytics) {
+			Scope(state: \.analytics, action: \.analytics) {
 				AnalyticsSettings()
 			}
-			Scope(state: /State.export, action: /Action.export) {
+			Scope(state: \.export, action: \.export) {
 				Export()
 			}
 		}
@@ -160,7 +160,7 @@ public struct HelpSettings: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 
@@ -255,16 +255,12 @@ public struct HelpSettingsView: View {
 				)
 			}
 			.navigationDestination(
-				store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-				state: /HelpSettings.Destination.State.analytics,
-				action: HelpSettings.Destination.Action.analytics
+				store: store.scope(state: \.$destination.analytics, action: \.internal.destination.analytics)
 			) {
 				AnalyticsSettingsView(store: $0)
 			}
 			.navigationDestination(
-				store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-				state: /HelpSettings.Destination.State.export,
-				action: HelpSettings.Destination.Action.export
+				store: store.scope(state: \.$destination.export, action: \.internal.destination.export)
 			) {
 				ExportView(store: $0)
 			}

--- a/ios/Approach/Sources/SettingsFeature/Help/HelpSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Help/HelpSettings.swift
@@ -81,7 +81,7 @@ public struct HelpSettings: Reducer {
 	@Dependency(\.openURL) var openURL
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/SettingsFeature/Help/HelpSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Help/HelpSettings.swift
@@ -30,8 +30,8 @@ public struct HelpSettings: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didTapReportBugButton
 			case didTapSendFeedbackButton
 			case didShowAcknowledgements
@@ -43,8 +43,8 @@ public struct HelpSettings: Reducer {
 			case didTapForceCrashButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case destination(PresentationAction<Destination.Action>)
 		}
 
@@ -60,7 +60,7 @@ public struct HelpSettings: Reducer {
 			case export(Export.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case analytics(AnalyticsSettings.Action)
 			case export(Export.Action)
 		}

--- a/ios/Approach/Sources/SettingsFeature/Settings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Settings.swift
@@ -36,8 +36,8 @@ public struct Settings: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didFirstAppear
 			case didTapPopulateDatabase
@@ -48,9 +48,9 @@ public struct Settings: Reducer {
 			case didTapAppIcon
 			case didTapVersionNumber
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didFetchIcon(TaskResult<AppIcon?>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didFetchIcon(Result<AppIcon?, Error>)
 			case didCopyToClipboard
 
 			case toast(ToastAction)
@@ -73,7 +73,7 @@ public struct Settings: Reducer {
 			case statistics(StatisticsSettings.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case archive(ArchiveList.Action)
 			case appIcon(AppIconList.Action)
 			case featureFlags(FeatureFlagsList.Action)
@@ -125,7 +125,7 @@ public struct Settings: Reducer {
 
 				case .didFirstAppear:
 					return .run { send in
-						await send(.internal(.didFetchIcon(TaskResult {
+						await send(.internal(.didFetchIcon(Result {
 							AppIcon(rawValue: await appIcon.getAppIconName() ?? "")
 						})))
 					}

--- a/ios/Approach/Sources/SettingsFeature/Settings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Settings.swift
@@ -82,19 +82,19 @@ public struct Settings: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.archive, action: /Action.archive) {
+			Scope(state: \.archive, action: \.archive) {
 				ArchiveList()
 			}
-			Scope(state: /State.appIcon, action: /Action.appIcon) {
+			Scope(state: \.appIcon, action: \.appIcon) {
 				AppIconList()
 			}
-			Scope(state: /State.featureFlags, action: /Action.featureFlags) {
+			Scope(state: \.featureFlags, action: \.featureFlags) {
 				FeatureFlagsList()
 			}
-			Scope(state: /State.opponentsList, action: /Action.opponentsList) {
+			Scope(state: \.opponentsList, action: \.opponentsList) {
 				OpponentsList()
 			}
-			Scope(state: /State.statistics, action: /Action.statistics) {
+			Scope(state: \.statistics, action: \.statistics) {
 				StatisticsSettings()
 			}
 		}
@@ -112,7 +112,7 @@ public struct Settings: Reducer {
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.helpSettings, action: /Action.internal..Action.InternalAction.helpSettings) {
+		Scope(state: \.helpSettings, action: \.internal.helpSettings) {
 			HelpSettings()
 		}
 
@@ -223,7 +223,7 @@ public struct Settings: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/SettingsFeature/SettingsView.swift
+++ b/ios/Approach/Sources/SettingsFeature/SettingsView.swift
@@ -2,6 +2,7 @@ import ArchiveListFeature
 import AssetsLibrary
 import ComposableArchitecture
 import ConstantsLibrary
+import ExtensionsLibrary
 import FeatureActionLibrary
 import FeatureFlagsListFeature
 import OpponentsListFeature
@@ -94,7 +95,7 @@ public struct SettingsView: View {
 					Text(Strings.Settings.Archive.footer)
 				}
 
-				HelpSettingsView(store: store.scope(state: \.helpSettings, action: /Settings.Action.InternalAction.helpSettings))
+				HelpSettingsView(store: store.scope(state: \.helpSettings, action: \.internal.helpSettings))
 
 				Section {
 					Button {
@@ -115,61 +116,43 @@ public struct SettingsView: View {
 			.onFirstAppear { viewStore.send(.didFirstAppear) }
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.toast(store: store.scope(state: \.toast, action: { .internal(.toast($0)) }))
-		.archive(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.appIconList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.opponentsList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.featureFlagsList(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.statisticsSettings(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
+		.toast(store: store.scope(state: \.toast, action: \.internal.toast))
+		.archive(store.scope(state: \.$destination.archive, action: \.internal.destination.archive))
+		.appIconList(store.scope(state: \.$destination.appIcon, action: \.internal.destination.appIcon))
+		.opponentsList(store.scope(state: \.$destination.opponentsList, action: \.internal.destination.opponentsList))
+		.featureFlagsList(store.scope(state: \.$destination.featureFlags, action: \.internal.destination.featureFlags))
+		.statisticsSettings(store.scope(state: \.$destination.statistics, action: \.internal.destination.statistics))
 	}
 }
 
 @MainActor extension View {
-	fileprivate typealias State = PresentationState<Settings.Destination.State>
-	fileprivate typealias Action = PresentationAction<Settings.Destination.Action>
-
-	fileprivate func archive(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /Settings.Destination.State.archive,
-			action: Settings.Destination.Action.archive,
-			destination: { ArchiveListView(store: $0) }
-		)
+	fileprivate func archive(_ store: PresentationStoreOf<ArchiveList>) -> some View {
+		navigationDestination(store: store) {
+			ArchiveListView(store: $0)
+		}
 	}
 
-	fileprivate func appIconList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /Settings.Destination.State.appIcon,
-			action: Settings.Destination.Action.appIcon,
-			destination: { AppIconListView(store: $0) }
-		)
+	fileprivate func appIconList(_ store: PresentationStoreOf<AppIconList>) -> some View {
+		navigationDestination(store: store) {
+			AppIconListView(store: $0)
+		}
 	}
 
-	fileprivate func opponentsList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /Settings.Destination.State.opponentsList,
-			action: Settings.Destination.Action.opponentsList,
-			destination: { OpponentsListView(store: $0) }
-		)
+	fileprivate func opponentsList(_ store: PresentationStoreOf<OpponentsList>) -> some View {
+		navigationDestination(store: store) {
+			OpponentsListView(store: $0)
+		}
 	}
 
-	fileprivate func featureFlagsList(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /Settings.Destination.State.featureFlags,
-			action: Settings.Destination.Action.featureFlags,
-			destination: { FeatureFlagsListView(store: $0) }
-		)
+	fileprivate func featureFlagsList(_ store: PresentationStoreOf<FeatureFlagsList>) -> some View {
+		navigationDestination(store: store) {
+			FeatureFlagsListView(store: $0)
+		}
 	}
 
-	fileprivate func statisticsSettings(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /Settings.Destination.State.statistics,
-			action: Settings.Destination.Action.statistics,
-			destination: { StatisticsSettingsView(store: $0) }
-		)
+	fileprivate func statisticsSettings(_ store: PresentationStoreOf<StatisticsSettings>) -> some View {
+		navigationDestination(store: store) {
+			StatisticsSettingsView(store: $0)
+		}
 	}
 }

--- a/ios/Approach/Sources/SettingsFeature/Statistics/StatisticsSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Statistics/StatisticsSettings.swift
@@ -49,7 +49,7 @@ public struct StatisticsSettings: Reducer {
 	@Dependency(\.preferences) var preferences
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/SettingsFeature/Statistics/StatisticsSettings.swift
+++ b/ios/Approach/Sources/SettingsFeature/Statistics/StatisticsSettings.swift
@@ -33,13 +33,13 @@ public struct StatisticsSettings: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/SharingFeature/Sharing.swift
+++ b/ios/Approach/Sources/SharingFeature/Sharing.swift
@@ -103,7 +103,7 @@ public struct Sharing: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 

--- a/ios/Approach/Sources/SharingFeature/Sharing.swift
+++ b/ios/Approach/Sources/SharingFeature/Sharing.swift
@@ -101,7 +101,7 @@ public struct Sharing: Reducer {
 	@Dependency(\.scores) var scores
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
 			Errors()

--- a/ios/Approach/Sources/SharingFeature/Sharing.swift
+++ b/ios/Approach/Sources/SharingFeature/Sharing.swift
@@ -62,8 +62,8 @@ public struct Sharing: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didFirstAppear
 			case didTapShareToStoriesButton
@@ -72,9 +72,9 @@ public struct Sharing: Reducer {
 			case didTapDoneButton
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didLoadGames(TaskResult<[Game.Shareable]>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didLoadGames(Result<[Game.Shareable], Error>)
 			case didLoadScore(ScoredGame)
 
 			case errors(Errors<ErrorID>.Action)
@@ -116,7 +116,7 @@ public struct Sharing: Reducer {
 
 				case .didFirstAppear:
 					return .run { [dataSource = state.dataSource] send in
-						await send(.internal(.didLoadGames(TaskResult {
+						await send(.internal(.didLoadGames(Result {
 							switch dataSource {
 							case let .games(ids):
 								return try await games.shareGames(ids)

--- a/ios/Approach/Sources/SharingFeature/SharingView.swift
+++ b/ios/Approach/Sources/SharingFeature/SharingView.swift
@@ -49,7 +49,7 @@ public struct SharingView: View {
 				viewStore.send(.binding(.set(\.$displayScale, $0)))
 			}
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 	}
 
 	@MainActor private func preview(

--- a/ios/Approach/Sources/SortOrderLibrary/SortOrder.swift
+++ b/ios/Approach/Sources/SortOrderLibrary/SortOrder.swift
@@ -14,12 +14,12 @@ public struct SortOrder<Ordering: Orderable>: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didTapOption(Ordering)
 		}
-		public enum InternalAction: Equatable { case doNothing }
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum InternalAction { case doNothing }
+		@CasePathable public enum DelegateAction {
 			case didTapOption(Ordering)
 		}
 

--- a/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsCharts.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsCharts.swift
@@ -16,14 +16,14 @@ public struct StatisticsDetailsCharts: Reducer {
 		public var isLoadingNextChart: Bool
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didChangeAggregation(TrackableFilter.Aggregation)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsCharts.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsCharts.swift
@@ -33,7 +33,7 @@ public struct StatisticsDetailsCharts: Reducer {
 	public init() {}
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsList.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsList.swift
@@ -41,17 +41,17 @@ public struct StatisticsDetailsList: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case didTapEntry(id: String)
 			case didTapDismissDescriptionsTip
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didRequestEntryDetails(id: String)
 			case listRequiresReload
 		}
-		public enum InternalAction: Equatable {
+		@CasePathable public enum InternalAction {
 			case scrollToEntry(id: Statistics.ListEntry.ID?)
 		}
 

--- a/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsList.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/Data/StatisticsDetailsList.swift
@@ -71,7 +71,7 @@ public struct StatisticsDetailsList: Reducer {
 	@Dependency(\.tips) var tips
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Reduce<State, Action> { state, action in
 			switch action {

--- a/ios/Approach/Sources/StatisticsDetailsFeature/Filter/StatisticsSourcePicker.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/Filter/StatisticsSourcePicker.swift
@@ -39,8 +39,8 @@ public struct StatisticsSourcePicker: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didFirstAppear
 			case didTapBowler
 			case didTapLeague
@@ -48,11 +48,11 @@ public struct StatisticsSourcePicker: Reducer {
 			case didTapGame
 			case didTapConfirmButton
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didChangeSource(TrackableFilter.Source)
 		}
-		public enum InternalAction: Equatable {
-			case didLoadSources(TaskResult<TrackableFilter.Sources?>)
+		@CasePathable public enum InternalAction {
+			case didLoadSources(Result<TrackableFilter.Sources?, Error>)
 			case destination(PresentationAction<Destination.Action>)
 			case errors(Errors<ErrorID>.Action)
 		}
@@ -70,7 +70,7 @@ public struct StatisticsSourcePicker: Reducer {
 			case gamePicker(ResourcePicker<Game.Summary, Series.ID>.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case bowlerPicker(ResourcePicker<Bowler.Summary, AlwaysEqual<Void>>.Action)
 			case leaguePicker(ResourcePicker<League.Summary, Bowler.ID>.Action)
 			case seriesPicker(ResourcePicker<Series.Summary, League.ID>.Action)
@@ -120,13 +120,13 @@ public struct StatisticsSourcePicker: Reducer {
 					state.isLoadingSources = true
 					if let source = state.sourceToLoad {
 						return .run { send in
-							await send(.internal(.didLoadSources(TaskResult {
+							await send(.internal(.didLoadSources(Result {
 								try await statistics.loadSources(source)
 							})))
 						}
 					} else {
 						return .run { send in
-							await send(.internal(.didLoadSources(TaskResult {
+							await send(.internal(.didLoadSources(Result {
 								try await statistics.loadDefaultSources()
 							})))
 						}

--- a/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails+Extensions.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails+Extensions.swift
@@ -3,7 +3,7 @@ import ComposableArchitecture
 extension MidGameStatisticsDetails {
 	func refreshStatistics(state: State) -> Effect<Action> {
 		.run { [filter = state.filter] send in
-			await send(.internal(.didLoadListEntries(TaskResult {
+			await send(.internal(.didLoadListEntries(Result {
 				try await statistics.load(for: filter)
 			})))
 		}

--- a/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails.swift
@@ -36,16 +36,16 @@ public struct MidGameStatisticsDetails: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case task
 			case onAppear
 			case didFirstAppear
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case didLoadListEntries(TaskResult<[Statistics.ListEntryGroup]>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case didLoadListEntries(Result<[Statistics.ListEntryGroup], Error>)
 
 			case list(StatisticsDetailsList.Action)
 			case errors(Errors<ErrorID>.Action)

--- a/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails.swift
@@ -71,11 +71,11 @@ public struct MidGameStatisticsDetails: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.list, action: /Action.internal..Action.InternalAction.list) {
+		Scope(state: \.list, action: \.internal.list) {
 			StatisticsDetailsList()
 		}
 

--- a/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetails.swift
@@ -69,7 +69,7 @@ public struct MidGameStatisticsDetails: Reducer {
 	@Dependency(\.statistics) var statistics
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
 			Errors()

--- a/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetailsView.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/MidGameStatisticsDetailsView.swift
@@ -24,7 +24,7 @@ public struct MidGameStatisticsDetailsView: View {
 		WithViewStore(store, observe: ViewState.init, send: { .view($0) }, content: { viewStore in
 			VStack {
 				StatisticsDetailsListView(
-					store: store.scope(state: \.list, action: { .internal(.list($0)) })
+					store: store.scope(state: \.list, action: \.internal.list)
 				) {
 					Section {
 						Picker(
@@ -45,7 +45,7 @@ public struct MidGameStatisticsDetailsView: View {
 			.onFirstAppear { viewStore.send(.didFirstAppear) }
 			.task { await viewStore.send(.task).finish() }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 	}
 }
 

--- a/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails+Extensions.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails+Extensions.swift
@@ -6,12 +6,12 @@ extension StatisticsDetails {
 	func refreshStatistics(state: State) -> Effect<Action> {
 		.merge(
 			.run { [filter = state.filter] send in
-				await send(.internal(.didLoadListEntries(TaskResult {
+				await send(.internal(.didLoadListEntries(Result {
 					try await statistics.load(for: filter)
 				})))
 			},
 			.run { [source = state.filter.source] send in
-				await send(.internal(.didLoadSources(TaskResult {
+				await send(.internal(.didLoadSources(Result {
 					try await statistics.loadSources(source)
 				})))
 			}
@@ -25,7 +25,7 @@ extension StatisticsDetails {
 			.run { send in
 				let startTime = date()
 
-				let result = await TaskResult { try await self.statistics.chart(statistic: forStatistic, filter: withFilter) }
+				let result = await Result { try await self.statistics.chart(statistic: forStatistic, filter: withFilter) }
 
 				let timeSpent = date().timeIntervalSince(startTime)
 				if timeSpent < Self.chartLoadingAnimationTime {

--- a/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails.swift
@@ -114,7 +114,7 @@ public struct StatisticsDetails: Reducer {
 	@Dependency(\.uiDeviceNotifications) var uiDevice
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
 			Errors()

--- a/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails.swift
@@ -85,10 +85,10 @@ public struct StatisticsDetails: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.list, action: /Action.list) {
+			Scope(state: \.list, action: \.list) {
 				StatisticsDetailsList()
 			}
-			Scope(state: /State.sourcePicker, action: /Action.sourcePicker) {
+			Scope(state: \.sourcePicker, action: \.sourcePicker) {
 				StatisticsSourcePicker()
 			}
 		}
@@ -116,11 +116,11 @@ public struct StatisticsDetails: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.charts, action: /Action.internal..Action.InternalAction.charts) {
+		Scope(state: \.charts, action: \.internal.charts) {
 			StatisticsDetailsCharts()
 		}
 
@@ -311,7 +311,7 @@ public struct StatisticsDetails: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetails.swift
@@ -44,16 +44,16 @@ public struct StatisticsDetails: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case didFirstAppear
 			case didTapSourcePicker
 			case didAdjustChartSize(backdropSize: CGSize, filtersSize: StatisticsFilterView.Size)
 			case binding(BindingAction<State>)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case destination(PresentationAction<Destination.Action>)
 			case charts(StatisticsDetailsCharts.Action)
 			case errors(Errors<ErrorID>.Action)
@@ -61,9 +61,9 @@ public struct StatisticsDetails: Reducer {
 			case didStartLoadingChart
 			case adjustBackdrop
 			case scrollListToEntry(Statistics.ListEntry.ID)
-			case didLoadSources(TaskResult<TrackableFilter.Sources?>)
-			case didLoadListEntries(TaskResult<[Statistics.ListEntryGroup]>)
-			case didLoadChartContent(TaskResult<Statistics.ChartContent>)
+			case didLoadSources(Result<TrackableFilter.Sources?, Error>)
+			case didLoadListEntries(Result<[Statistics.ListEntryGroup], Error>)
+			case didLoadChartContent(Result<Statistics.ChartContent, Error>)
 			case orientationChange(UIDeviceOrientation)
 		}
 
@@ -79,7 +79,7 @@ public struct StatisticsDetails: Reducer {
 			case sourcePicker(StatisticsSourcePicker.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case list(StatisticsDetailsList.Action)
 			case sourcePicker(StatisticsSourcePicker.Action)
 		}

--- a/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetailsView.swift
+++ b/ios/Approach/Sources/StatisticsDetailsFeature/StatisticsDetailsView.swift
@@ -44,7 +44,7 @@ public struct StatisticsDetailsView: View {
 					}
 
 					StatisticsDetailsChartsView(
-						store: store.scope(state: \.charts, action: /StatisticsDetails.Action.InternalAction.charts)
+						store: store.scope(state: \.charts, action: \.internal.charts)
 					)
 					.padding(.horizontal)
 					.layoutPriority(1)
@@ -66,9 +66,7 @@ public struct StatisticsDetailsView: View {
 				}
 			}
 			.sheet(
-				store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-				state: /StatisticsDetails.Destination.State.list,
-				action: StatisticsDetails.Destination.Action.list
+				store: store.scope(state: \.$destination.list, action: \.internal.destination.list)
 			) { store in
 				NavigationStack {
 					StatisticsDetailsListView(store: store)
@@ -107,11 +105,9 @@ public struct StatisticsDetailsView: View {
 			.task { await viewStore.send(.didFirstAppear).finish() }
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /StatisticsDetails.Destination.State.sourcePicker,
-			action: StatisticsDetails.Destination.Action.sourcePicker
+			store: store.scope(state: \.$destination.sourcePicker, action: \.internal.destination.sourcePicker)
 		) { store in
 			NavigationStack {
 				StatisticsSourcePickerView(store: store)

--- a/ios/Approach/Sources/StatisticsOverviewFeature/StatisticsOverview.swift
+++ b/ios/Approach/Sources/StatisticsOverviewFeature/StatisticsOverview.swift
@@ -56,10 +56,10 @@ public struct StatisticsOverview: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.sourcePicker, action: /Action.sourcePicker) {
+			Scope(state: \.sourcePicker, action: \.sourcePicker) {
 				StatisticsSourcePicker()
 			}
-			Scope(state: /State.details, action: /Action.details) {
+			Scope(state: \.details, action: \.details) {
 				StatisticsDetails()
 			}
 		}
@@ -129,7 +129,7 @@ public struct StatisticsOverview: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/StatisticsOverviewFeature/StatisticsOverview.swift
+++ b/ios/Approach/Sources/StatisticsOverviewFeature/StatisticsOverview.swift
@@ -25,16 +25,16 @@ public struct StatisticsOverview: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case onAppear
 			case didTapDismissOverviewTip
 			case didTapDismissDetailsTip
 			case didTapViewDetailedStatistics
 			case sourcePickerDidDismiss
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
 			case destination(PresentationAction<Destination.Action>)
 		}
 
@@ -50,7 +50,7 @@ public struct StatisticsOverview: Reducer {
 			case details(StatisticsDetails.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case sourcePicker(StatisticsSourcePicker.Action)
 			case details(StatisticsDetails.Action)
 		}

--- a/ios/Approach/Sources/StatisticsOverviewFeature/StatisticsOverviewView.swift
+++ b/ios/Approach/Sources/StatisticsOverviewFeature/StatisticsOverviewView.swift
@@ -61,9 +61,7 @@ public struct StatisticsOverviewView: View {
 			.navigationTitle(Strings.Statistics.title)
 			.onAppear { viewStore.send(.onAppear) }
 			.sheet(
-				store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-				state: /StatisticsOverview.Destination.State.sourcePicker,
-				action: StatisticsOverview.Destination.Action.sourcePicker,
+				store: store.scope(state: \.$destination.sourcePicker, action: \.internal.destination.sourcePicker),
 				onDismiss: { viewStore.send(.sourcePickerDidDismiss) },
 				content: { store in
 					NavigationStack {
@@ -74,9 +72,7 @@ public struct StatisticsOverviewView: View {
 			)
 		})
 		.navigationDestination(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /StatisticsOverview.Destination.State.details,
-			action: StatisticsOverview.Destination.Action.details
+			store: store.scope(state: \.$destination.details, action: \.internal.destination.details)
 		) { store in
 			StatisticsDetailsView(store: store)
 		}

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilder.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilder.swift
@@ -84,11 +84,11 @@ public struct StatisticsWidgetLayoutBuilder: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
-		Scope(state: \.reordering, action: /Action.internal..Action.InternalAction.reordering) {
+		Scope(state: \.reordering, action: \.internal.reordering) {
 			Reorderable()
 		}
 
@@ -235,7 +235,7 @@ public struct StatisticsWidgetLayoutBuilder: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$editor, action: /Action.internal..Action.InternalAction.editor) {
+		.ifLet(\.$editor, action: \.internal.editor) {
 			StatisticsWidgetEditor()
 		}
 

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilder.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilder.swift
@@ -82,7 +82,7 @@ public struct StatisticsWidgetLayoutBuilder: Reducer {
 	@Dependency(\.statisticsWidgets) var statisticsWidgets
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
 			Errors()

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilder.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilder.swift
@@ -33,8 +33,8 @@ public struct StatisticsWidgetLayoutBuilder: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: BindableAction, Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction: BindableAction {
 			case onAppear
 			case task
 			case didTapAddNew
@@ -46,12 +46,12 @@ public struct StatisticsWidgetLayoutBuilder: Reducer {
 			case binding(BindingAction<State>)
 
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case widgetsResponse(TaskResult<[StatisticsWidget.Configuration]>)
-			case didLoadChartContent(id: StatisticsWidget.ID, TaskResult<Statistics.ChartContent>)
-			case didUpdatePriorities(TaskResult<Never>)
-			case didDeleteWidget(TaskResult<Never>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case widgetsResponse(Result<[StatisticsWidget.Configuration], Error>)
+			case didLoadChartContent(id: StatisticsWidget.ID, Result<Statistics.ChartContent, Error>)
+			case didUpdatePriorities(Result<Never, Error>)
+			case didDeleteWidget(Result<Never, Error>)
 
 			case startAnimatingWidgets
 			case stopAnimatingWidgets
@@ -169,7 +169,7 @@ public struct StatisticsWidgetLayoutBuilder: Reducer {
 
 					let chartTasks: [Effect<Action>] = state.widgets.map { widget in
 						.run { send in
-							await send(.internal(.didLoadChartContent(id: widget.id, TaskResult {
+							await send(.internal(.didLoadChartContent(id: widget.id, Result {
 								try await self.statisticsWidgets.chart(widget)
 							})))
 						}

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilderView.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Builder/StatisticsWidgetLayoutBuilderView.swift
@@ -32,7 +32,7 @@ public struct StatisticsWidgetLayoutBuilderView: View {
 					spacing: .largeSpacing
 				) {
 					ReorderableView(
-						store: store.scope(state: \.reordering, action: { .internal(.reordering($0)) })
+						store: store.scope(state: \.reordering, action: \.internal.reordering)
 					) { widget in
 						MoveableWidget(
 							configuration: widget,
@@ -82,7 +82,7 @@ public struct StatisticsWidgetLayoutBuilderView: View {
 			.task { await viewStore.send(.task).finish() }
 			.onAppear { viewStore.send(.onAppear) }
 			.sheet(
-				store: store.scope(state: \.$editor, action: { .internal(.editor($0)) }),
+				store: store.scope(state: \.$editor, action: \.internal.editor),
 				onDismiss: { viewStore.send(.didFinishDismissingEditor) },
 				content: { store in
 					NavigationStack {
@@ -91,7 +91,7 @@ public struct StatisticsWidgetLayoutBuilderView: View {
 				}
 			)
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 	}
 }
 

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticPicker.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticPicker.swift
@@ -27,14 +27,14 @@ public struct StatisticPicker: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didTapStatistic(String)
 		}
-		public enum DelegateAction: Equatable {
+		@CasePathable public enum DelegateAction {
 			case didSelectStatistic(String)
 		}
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticsWidgetEditor.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticsWidgetEditor.swift
@@ -125,16 +125,16 @@ public struct StatisticsWidgetEditor: Reducer {
 		@Dependency(\.leagues) var leagues
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.bowlerPicker, action: /Action.bowlerPicker) {
+			Scope(state: \.bowlerPicker, action: \.bowlerPicker) {
 				ResourcePicker { _ in bowlers.pickable() }
 			}
-			Scope(state: /State.leaguePicker, action: /Action.leaguePicker) {
+			Scope(state: \.leaguePicker, action: \.leaguePicker) {
 				ResourcePicker { bowler in leagues.pickable(bowledBy: bowler, ordering: .byName) }
 			}
-			Scope(state: /State.help, action: /Action.help) {
+			Scope(state: \.help, action: \.help) {
 				StatisticsWidgetHelp()
 			}
-			Scope(state: /State.statisticPicker, action: /Action.statisticPicker) {
+			Scope(state: \.statisticPicker, action: \.statisticPicker) {
 				StatisticPicker()
 			}
 		}
@@ -162,7 +162,7 @@ public struct StatisticsWidgetEditor: Reducer {
 	public var body: some ReducerOf<Self> {
 		BindingReducer(action: \.view)
 
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
@@ -342,7 +342,7 @@ public struct StatisticsWidgetEditor: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticsWidgetEditor.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticsWidgetEditor.swift
@@ -160,7 +160,7 @@ public struct StatisticsWidgetEditor: Reducer {
 	@Dependency(\.uuid) var uuid
 
 	public var body: some ReducerOf<Self> {
-		BindingReducer(action: /Action.view)
+		BindingReducer(action: \.view)
 
 		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
 			Errors()

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticsWidgetEditorView.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Editor/StatisticsWidgetEditorView.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import EquatableLibrary
 import ErrorsFeature
+import ExtensionsLibrary
 import ModelsLibrary
 import ModelsViewsLibrary
 import ResourcePickerLibrary
@@ -119,58 +120,43 @@ public struct StatisticsWidgetEditorView: View {
 			.onFirstAppear { viewStore.send(.didFirstAppear) }
 			.onAppear { viewStore.send(.onAppear) }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
-		.bowlerPicker(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.leaguePicker(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.statisticPicker(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
-		.help(store.scope(state: \.$destination, action: { .internal(.destination($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
+		.bowlerPicker(store.scope(state: \.$destination.bowlerPicker, action: \.internal.destination.bowlerPicker))
+		.leaguePicker(store.scope(state: \.$destination.leaguePicker, action: \.internal.destination.leaguePicker))
+		.statisticPicker(store.scope(state: \.$destination.statisticPicker, action: \.internal.destination.statisticPicker))
+		.help(store.scope(state: \.$destination.help, action: \.internal.destination.help))
 	}
 }
 
 @MainActor extension View {
-	fileprivate typealias State = PresentationState<StatisticsWidgetEditor.Destination.State>
-	fileprivate typealias Action = PresentationAction<StatisticsWidgetEditor.Destination.Action>
-
-	fileprivate func bowlerPicker(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /StatisticsWidgetEditor.Destination.State.bowlerPicker,
-			action: StatisticsWidgetEditor.Destination.Action.bowlerPicker
-		) { (store: StoreOf<ResourcePicker<Bowler.Summary, AlwaysEqual<Void>>>) in
+	fileprivate func bowlerPicker(
+		_ store: PresentationStoreOf<ResourcePicker<Bowler.Summary, AlwaysEqual<Void>>>
+	) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<ResourcePicker<Bowler.Summary, AlwaysEqual<Void>>>) in
 			ResourcePickerView(store: store) { bowler in
 				Bowler.View(bowler)
 			}
 		}
 	}
 
-	fileprivate func leaguePicker(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /StatisticsWidgetEditor.Destination.State.leaguePicker,
-			action: StatisticsWidgetEditor.Destination.Action.leaguePicker
-		) { (store: StoreOf<ResourcePicker<League.Summary, Bowler.ID>>) in
+	fileprivate func leaguePicker(
+		_ store: PresentationStoreOf<ResourcePicker<League.Summary, Bowler.ID>>
+	) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<ResourcePicker<League.Summary, Bowler.ID>>) in
 			ResourcePickerView(store: store) { league in
 				Text(league.name)
 			}
 		}
 	}
 
-	fileprivate func statisticPicker(_ store: Store<State, Action>) -> some View {
-		navigationDestination(
-			store: store,
-			state: /StatisticsWidgetEditor.Destination.State.statisticPicker,
-			action: StatisticsWidgetEditor.Destination.Action.statisticPicker
-		) { (store: StoreOf<StatisticPicker>) in
+	fileprivate func statisticPicker(_ store: PresentationStoreOf<StatisticPicker>) -> some View {
+		navigationDestination(store: store) { (store: StoreOf<StatisticPicker>) in
 			StatisticPickerView(store: store)
 		}
 	}
 
-	fileprivate func help(_ store: Store<State, Action>) -> some View {
-		sheet(
-			store: store,
-			state: /StatisticsWidgetEditor.Destination.State.help,
-			action: StatisticsWidgetEditor.Destination.Action.help
-		) { (store: StoreOf<StatisticsWidgetHelp>) in
+	fileprivate func help(_ store: PresentationStoreOf<StatisticsWidgetHelp>) -> some View {
+		sheet(store: store) { (store: StoreOf<StatisticsWidgetHelp>) in
 			NavigationStack {
 				StatisticsWidgetHelpView(store: store)
 			}

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Layout/StatisticsWidgetHelp.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Layout/StatisticsWidgetHelp.swift
@@ -21,12 +21,12 @@ public struct StatisticsWidgetHelp: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case didTapDoneButton
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable { case doNothing }
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction { case doNothing }
 
 		case view(ViewAction)
 		case delegate(DelegateAction)

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Layout/StatisticsWidgetLayout.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Layout/StatisticsWidgetLayout.swift
@@ -30,16 +30,16 @@ public struct StatisticsWidgetLayout: Reducer {
 		}
 	}
 
-	public enum Action: FeatureAction, Equatable {
-		public enum ViewAction: Equatable {
+	public enum Action: FeatureAction {
+		@CasePathable public enum ViewAction {
 			case task
 			case didTapConfigureStatisticsButton
 			case didTapWidget(id: StatisticsWidget.ID)
 		}
-		public enum DelegateAction: Equatable { case doNothing }
-		public enum InternalAction: Equatable {
-			case widgetsResponse(TaskResult<[StatisticsWidget.Configuration]>)
-			case didLoadChartContent(id: StatisticsWidget.ID, TaskResult<Statistics.ChartContent>)
+		@CasePathable public enum DelegateAction { case doNothing }
+		@CasePathable public enum InternalAction {
+			case widgetsResponse(Result<[StatisticsWidget.Configuration], Error>)
+			case didLoadChartContent(id: StatisticsWidget.ID, Result<Statistics.ChartContent, Error>)
 
 			case errors(Errors<ErrorID>.Action)
 			case destination(PresentationAction<Destination.Action>)
@@ -58,7 +58,7 @@ public struct StatisticsWidgetLayout: Reducer {
 			case help(StatisticsWidgetHelp.State)
 		}
 
-		public enum Action: Equatable {
+		public enum Action {
 			case details(StatisticsDetails.Action)
 			case layout(StatisticsWidgetLayoutBuilder.Action)
 			case help(StatisticsWidgetHelp.Action)
@@ -131,7 +131,7 @@ public struct StatisticsWidgetLayout: Reducer {
 					state.widgets = .init(uniqueElements: widgets)
 					let chartTasks: [Effect<Action>]? = state.widgets?.map { widget in
 						.run { send in
-							await send(.internal(.didLoadChartContent(id: widget.id, TaskResult {
+							await send(.internal(.didLoadChartContent(id: widget.id, Result {
 								try await self.statisticsWidgets.chart(widget)
 							})))
 						}

--- a/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Layout/StatisticsWidgetLayout.swift
+++ b/ios/Approach/Sources/StatisticsWidgetsLayoutFeature/Layout/StatisticsWidgetLayout.swift
@@ -65,13 +65,13 @@ public struct StatisticsWidgetLayout: Reducer {
 		}
 
 		public var body: some ReducerOf<Self> {
-			Scope(state: /State.details, action: /Action.details) {
+			Scope(state: \.details, action: \.details) {
 				StatisticsDetails()
 			}
-			Scope(state: /State.layout, action: /Action.layout) {
+			Scope(state: \.layout, action: \.layout) {
 				StatisticsWidgetLayoutBuilder()
 			}
-			Scope(state: /State.help, action: /Action.help) {
+			Scope(state: \.help, action: \.help) {
 				StatisticsWidgetHelp()
 			}
 		}
@@ -90,7 +90,7 @@ public struct StatisticsWidgetLayout: Reducer {
 	@Dependency(\.statisticsWidgets) var statisticsWidgets
 
 	public var body: some ReducerOf<Self> {
-		Scope(state: \.errors, action: /Action.internal..Action.InternalAction.errors) {
+		Scope(state: \.errors, action: \.internal.errors) {
 			Errors()
 		}
 
@@ -175,7 +175,7 @@ public struct StatisticsWidgetLayout: Reducer {
 				return .none
 			}
 		}
-		.ifLet(\.$destination, action: /Action.internal..Action.InternalAction.destination) {
+		.ifLet(\.$destination, action: \.internal.destination) {
 			Destination()
 		}
 	}
@@ -281,18 +281,14 @@ public struct StatisticsWidgetLayoutView: View {
 			}
 			.task { await viewStore.send(.task).finish() }
 		})
-		.errors(store: store.scope(state: \.errors, action: { .internal(.errors($0)) }))
+		.errors(store: store.scope(state: \.errors, action: \.internal.errors))
 		.navigationDestination(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /StatisticsWidgetLayout.Destination.State.details,
-			action: StatisticsWidgetLayout.Destination.Action.details
+			store: store.scope(state: \.$destination.details, action: \.internal.destination.details)
 		) { (store: StoreOf<StatisticsDetails>) in
 			StatisticsDetailsView(store: store)
 		}
 		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /StatisticsWidgetLayout.Destination.State.layout,
-			action: StatisticsWidgetLayout.Destination.Action.layout
+			store: store.scope(state: \.$destination.layout, action: \.internal.destination.layout)
 		) { (store: StoreOf<StatisticsWidgetLayoutBuilder>) in
 			NavigationStack {
 				StatisticsWidgetLayoutBuilderView(store: store)
@@ -300,9 +296,7 @@ public struct StatisticsWidgetLayoutView: View {
 			.interactiveDismissDisabled()
 		}
 		.sheet(
-			store: store.scope(state: \.$destination, action: { .internal(.destination($0)) }),
-			state: /StatisticsWidgetLayout.Destination.State.help,
-			action: StatisticsWidgetLayout.Destination.Action.help
+			store: store.scope(state: \.$destination.help, action: \.internal.destination.help)
 		) { (store: StoreOf<StatisticsWidgetHelp>) in
 			NavigationStack {
 				StatisticsWidgetHelpView(store: store)


### PR DESCRIPTION
Fixes #395, #396 

Complete all steps outlined in in the [Migrating to 1.4](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.4/) and [Migrating to 1.5](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.5/) documents.

Mostly finished with Find + Replace, along with some destinations being pulled out of inline definitions to View extensions