### PR TITLE
fix(android): navigate to series after its created

### DIFF
--- a/android/app/src/main/java/ca/josephroque/bowlingcompanion/navigation/ApproachNavHost.kt
+++ b/android/app/src/main/java/ca/josephroque/bowlingcompanion/navigation/ApproachNavHost.kt
@@ -147,12 +147,14 @@ fun ApproachNavHost(
 			)
 			leagueDetailsScreen(
 				onEditSeries = navController::navigateToSeriesForm,
-				onAddSeries = navController::navigateToNewSeriesForm,
+				onAddSeries = { leagueId, result ->
+					navController.navigateToNewSeriesForm(leagueId, result)
+				},
 				onShowSeriesDetails = navController::navigateToSeriesDetails,
 				onBackPressed = navController::popBackStack,
 			)
 			seriesFormScreen(
-				onBackPressed = navController::popBackStack,
+				onDismissWithResult = navController::popBackStackWithResult,
 				onEditAlley = { alley, result ->
 					navController.navigateToResourcePickerForResult(
 						selectedIds = alley?.let { setOf(it) } ?: emptySet(),

--- a/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/LeagueDetailsScreen.kt
+++ b/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/LeagueDetailsScreen.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import ca.josephroque.bowlingcompanion.core.common.navigation.NavResultCallback
 import ca.josephroque.bowlingcompanion.feature.leaguedetails.ui.LeagueDetails
 import ca.josephroque.bowlingcompanion.feature.leaguedetails.ui.LeagueDetailsTopBar
 import ca.josephroque.bowlingcompanion.feature.leaguedetails.ui.LeagueDetailsTopBarUiState
@@ -25,7 +26,7 @@ import java.util.UUID
 internal fun LeagueDetailsRoute(
 	onBackPressed: () -> Unit,
 	onEditSeries: (UUID) -> Unit,
-	onAddSeries: (UUID) -> Unit,
+	onAddSeries: (UUID, NavResultCallback<UUID?>) -> Unit,
 	onShowSeriesDetails: (UUID) -> Unit,
 	modifier: Modifier = Modifier,
 	viewModel: LeagueDetailsViewModel = hiltViewModel(),
@@ -39,7 +40,10 @@ internal fun LeagueDetailsRoute(
 				.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
 				.collect {
 					when (it) {
-						is LeagueDetailsScreenEvent.AddSeries -> onAddSeries(it.leagueId)
+						is LeagueDetailsScreenEvent.AddSeries -> onAddSeries(it.leagueId) { seriesId ->
+							seriesId ?: return@onAddSeries
+							viewModel.handleAction(LeagueDetailsScreenUiAction.SeriesAdded(seriesId))
+						}
 						is LeagueDetailsScreenEvent.EditSeries -> onEditSeries(it.seriesId)
 						is LeagueDetailsScreenEvent.Dismissed -> onBackPressed()
 						is LeagueDetailsScreenEvent.ShowSeriesDetails -> onShowSeriesDetails(it.seriesId)

--- a/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/LeagueDetailsScreenUi.kt
+++ b/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/LeagueDetailsScreenUi.kt
@@ -13,6 +13,7 @@ sealed interface LeagueDetailsScreenUiState {
 }
 
 sealed interface LeagueDetailsScreenUiAction {
+	data class SeriesAdded(val seriesId: UUID): LeagueDetailsScreenUiAction
 	data class LeagueDetails(val action: LeagueDetailsUiAction): LeagueDetailsScreenUiAction
 }
 

--- a/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/LeagueDetailsViewModel.kt
+++ b/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/LeagueDetailsViewModel.kt
@@ -113,6 +113,7 @@ class LeagueDetailsViewModel @Inject constructor(
 
 	fun handleAction(action: LeagueDetailsScreenUiAction) {
 		when (action) {
+			is LeagueDetailsScreenUiAction.SeriesAdded -> showSeriesDetails(action.seriesId)
 			is LeagueDetailsScreenUiAction.LeagueDetails -> handleLeagueDetailsAction(action.action)
 		}
 	}
@@ -136,13 +137,17 @@ class LeagueDetailsViewModel @Inject constructor(
 
 	private fun handleSeriesListAction(action: SeriesListUiAction) {
 		when (action) {
-			is SeriesListUiAction.SeriesClicked -> sendEvent(LeagueDetailsScreenEvent.ShowSeriesDetails(action.id))
+			is SeriesListUiAction.SeriesClicked -> showSeriesDetails(action.id)
 			is SeriesListUiAction.EditSeriesClicked -> sendEvent(LeagueDetailsScreenEvent.EditSeries(action.id))
 			SeriesListUiAction.AddSeriesClicked -> sendEvent(LeagueDetailsScreenEvent.AddSeries(leagueId))
 			is SeriesListUiAction.ArchiveSeriesClicked -> _seriesToArchive.value = action.series
 			SeriesListUiAction.ConfirmArchiveClicked -> archiveSeries()
 			SeriesListUiAction.DismissArchiveClicked -> _seriesToArchive.value = null
 		}
+	}
+
+	private fun showSeriesDetails(seriesId: UUID) {
+		sendEvent(LeagueDetailsScreenEvent.ShowSeriesDetails(seriesId))
 	}
 
 	private fun archiveSeries() {

--- a/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/navigation/LeagueDetailsNavigation.kt
+++ b/android/feature/leaguedetails/src/main/java/ca/josephroque/bowlingcompanion/feature/leaguedetails/navigation/LeagueDetailsNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import ca.josephroque.bowlingcompanion.core.common.navigation.NavResultCallback
 import ca.josephroque.bowlingcompanion.feature.leaguedetails.LeagueDetailsRoute
 import java.util.UUID
 
@@ -20,7 +21,7 @@ fun NavController.navigateToLeagueDetails(leagueId: UUID) {
 fun NavGraphBuilder.leagueDetailsScreen(
 	onBackPressed: () -> Unit,
 	onEditSeries: (UUID) -> Unit,
-	onAddSeries: (UUID) -> Unit,
+	onAddSeries: (UUID, NavResultCallback<UUID?>) -> Unit,
 	onShowSeriesDetails: (UUID) -> Unit,
 ) {
 	composable(

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreen.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreen.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 
 @Composable
 internal fun SeriesFormRoute(
-	onDismiss: () -> Unit,
+	onDismissWithResult: (UUID?) -> Unit,
 	onEditAlley: (UUID?, NavResultCallback<Set<UUID>>) -> Unit,
 	modifier: Modifier = Modifier,
 	viewModel: SeriesFormViewModel = hiltViewModel(),
@@ -37,7 +37,7 @@ internal fun SeriesFormRoute(
 				.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
 				.collect {
 					when (it) {
-						SeriesFormScreenEvent.Dismissed -> onDismiss()
+						is SeriesFormScreenEvent.Dismissed -> onDismissWithResult(it.id)
 						is SeriesFormScreenEvent.EditAlley ->
 							onEditAlley(it.alleyId) { ids ->
 								viewModel.handleAction(SeriesFormScreenUiAction.AlleyUpdated(ids.firstOrNull()))

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreenUi.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreenUi.kt
@@ -38,6 +38,6 @@ sealed interface SeriesFormScreenUiAction {
 }
 
 sealed interface SeriesFormScreenEvent {
-	data object Dismissed: SeriesFormScreenEvent
+	data class Dismissed(val id: UUID?): SeriesFormScreenEvent
 	data class EditAlley(val alleyId: UUID?): SeriesFormScreenEvent
 }

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormViewModel.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormViewModel.kt
@@ -58,7 +58,7 @@ class SeriesFormViewModel @Inject constructor(
 
 	private fun handleSeriesFormAction(action: SeriesFormUiAction) {
 		when (action) {
-			SeriesFormUiAction.BackClicked -> sendEvent(SeriesFormScreenEvent.Dismissed)
+			SeriesFormUiAction.BackClicked -> dismiss()
 			SeriesFormUiAction.DoneClicked -> saveSeries()
 			SeriesFormUiAction.ArchiveClicked -> setArchiveSeriesPrompt(isVisible = true)
 			SeriesFormUiAction.ConfirmArchiveClicked -> archiveSeries()
@@ -171,7 +171,7 @@ class SeriesFormViewModel @Inject constructor(
 
 			seriesRepository.archiveSeries(series.id)
 			setFormUiState(state = formState.copy(isShowingArchiveDialog = false))
-			sendEvent(SeriesFormScreenEvent.Dismissed)
+			dismiss()
 		}
 	}
 
@@ -216,14 +216,18 @@ class SeriesFormViewModel @Inject constructor(
 					)
 
 					seriesRepository.insertSeries(series)
-					sendEvent(SeriesFormScreenEvent.Dismissed)
+					dismiss(seriesId = series.id)
 				}
 				is SeriesFormScreenUiState.Edit -> {
 					val series = state.form.updatedModel(state.initialValue)
 					seriesRepository.updateSeries(series)
-					sendEvent(SeriesFormScreenEvent.Dismissed)
+					dismiss()
 				}
 			}
 		}
+	}
+
+	private fun dismiss(seriesId: UUID? = null) {
+		sendEvent(SeriesFormScreenEvent.Dismissed(seriesId))
 	}
 }

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/navigation/SeriesFormNavigation.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/navigation/SeriesFormNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import ca.josephroque.bowlingcompanion.core.common.navigation.NavResultCallback
+import ca.josephroque.bowlingcompanion.core.common.navigation.navigateForResult
 import ca.josephroque.bowlingcompanion.feature.seriesform.SeriesFormRoute
 import java.util.UUID
 
@@ -20,13 +21,13 @@ fun NavController.navigateToSeriesForm(seriesId: UUID) {
 	this.navigate("edit_series/$encoded")
 }
 
-fun NavController.navigateToNewSeriesForm(leagueId: UUID) {
+fun NavController.navigateToNewSeriesForm(leagueId: UUID, result: NavResultCallback<UUID?>) {
 	val encoded = UUID.fromString(leagueId.toString())
-	this.navigate("add_series/$encoded")
+	this.navigateForResult("add_series/$encoded", result)
 }
 
 fun NavGraphBuilder.seriesFormScreen(
-	onBackPressed: () -> Unit,
+	onDismissWithResult: (UUID?) -> Unit,
 	onEditAlley: (UUID?, NavResultCallback<Set<UUID>>) -> Unit,
 ) {
 	composable(
@@ -36,7 +37,7 @@ fun NavGraphBuilder.seriesFormScreen(
 		),
 	) {
 		SeriesFormRoute(
-			onDismiss = onBackPressed,
+			onDismissWithResult = onDismissWithResult,
 			onEditAlley = onEditAlley,
 		)
 	}
@@ -47,7 +48,7 @@ fun NavGraphBuilder.seriesFormScreen(
 		),
 	) {
 		SeriesFormRoute(
-			onDismiss = onBackPressed,
+			onDismissWithResult = onDismissWithResult,
 			onEditAlley = onEditAlley,
 		)
 	}


### PR DESCRIPTION
Fixes #424

Navigates to a series after it's created by returning the ID to the `LeagueDetails`