### PR TITLE
Enable game locking

### DIFF
--- a/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/GamesEditorScreen.kt
+++ b/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/GamesEditorScreen.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
@@ -14,6 +17,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -81,6 +85,25 @@ internal fun GamesEditorScreen(
 
 	LaunchedEffect(Unit) {
 		onAction(GamesEditorScreenUiAction.LoadInitialGame)
+	}
+
+	val snackBarLockedMessage = stringResource(R.string.game_editor_locked)
+	val coroutineScope = rememberCoroutineScope()
+	val isGameLockSnackBarVisible = state is GamesEditorScreenUiState.Loaded && state.isGameLockSnackBarVisible
+	LaunchedEffect(isGameLockSnackBarVisible) {
+		if (isGameLockSnackBarVisible) {
+			coroutineScope.launch {
+				val result = scaffoldState.snackbarHostState.showSnackbar(
+					message = snackBarLockedMessage,
+					duration = SnackbarDuration.Short,
+				)
+
+				when (result) {
+					SnackbarResult.Dismissed -> onAction(GamesEditorScreenUiAction.GameLockSnackBarDismissed)
+					SnackbarResult.ActionPerformed -> onAction(GamesEditorScreenUiAction.GameLockSnackBarDismissed)
+				}
+			}
+		}
 	}
 
 	BottomSheetScaffold(

--- a/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/GamesEditorScreenUi.kt
+++ b/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/GamesEditorScreenUi.kt
@@ -11,6 +11,7 @@ sealed interface GamesEditorScreenUiState {
 
 	data class Loaded(
 		val headerPeekHeight: Float = 0f,
+		val isGameLockSnackBarVisible: Boolean = false,
 		val gameDetails: GameDetailsUiState,
 		val gamesEditor: GamesEditorUiState,
 	): GamesEditorScreenUiState
@@ -18,6 +19,7 @@ sealed interface GamesEditorScreenUiState {
 
 sealed interface GamesEditorScreenUiAction {
 	data object LoadInitialGame: GamesEditorScreenUiAction
+	data object GameLockSnackBarDismissed: GamesEditorScreenUiAction
 
 	data class GearUpdated(val gearIds: Set<UUID>): GamesEditorScreenUiAction
 	data class GamesEditor(val action: GamesEditorUiAction): GamesEditorScreenUiAction

--- a/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/utils/FrameUtilities.kt
+++ b/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/utils/FrameUtilities.kt
@@ -46,18 +46,18 @@ fun MutableList<FrameEdit>.setBallRolled(
 	this[frameIndex] = frame.copy(rolls = rolls)
 }
 
-fun MutableList<FrameEdit>.ensureFramesExist(upTo: Int) {
-	for (frameIndex in 0..upTo) {
-		val numberOfRolls = this[frameIndex].rolls.size
-		if (numberOfRolls == Frame.NumberOfRolls) continue
-		val lastRollIndex = numberOfRolls - 1
-		if (!this[frameIndex].deckForRoll(lastRollIndex).arePinsCleared()) {
-			this[frameIndex] = this[frameIndex].ensureRollExists(upTo = Frame.NumberOfRolls - 1)
-		}
-	}
+fun List<FrameEdit>.doesRollExistInFrame(frameIndex: Int, rollIndex: Int): Boolean {
+	if (frameIndex >= this.size) return false
+	return rollIndex < this[frameIndex].rolls.size
+}
+
+fun MutableList<FrameEdit>.guaranteeRollExists(frameIndex: Int, rollIndex: Int) {
+	this[frameIndex] = this[frameIndex].ensureRollExists(upTo = rollIndex)
 }
 
 fun FrameEdit.ensureRollExists(upTo: Int): FrameEdit {
+	if (this.rolls.size == upTo + 1) return this
+
 	val rolls = this.rolls.toMutableList()
 	for (rollIndex in this.rolls.size..upTo) {
 		rolls.add(FrameEdit.Roll(index = rollIndex, pinsDowned = emptySet(), didFoul = false, bowlingBall = null))

--- a/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/utils/GameUtilities.kt
+++ b/android/feature/gameseditor/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/utils/GameUtilities.kt
@@ -6,7 +6,6 @@ import ca.josephroque.bowlingcompanion.core.model.GameLockState
 import ca.josephroque.bowlingcompanion.core.model.GameScoringMethod
 import ca.josephroque.bowlingcompanion.core.model.Roll
 import ca.josephroque.bowlingcompanion.core.model.arePinsCleared
-import ca.josephroque.bowlingcompanion.core.model.nextFrameToRecord
 import ca.josephroque.bowlingcompanion.core.scoresheet.ScoreSheetUiState
 import ca.josephroque.bowlingcompanion.feature.gameseditor.ui.GamesEditorUiState
 import ca.josephroque.bowlingcompanion.feature.gameseditor.ui.gamedetails.GameDetailsUiState
@@ -116,6 +115,17 @@ fun GamesEditorUiState.updateSelection(frameIndex: Int?, rollIndex: Int?): Games
 	val lastAccessibleRollInFrame = frames[selection.frameIndex].lastAccessibleRollIndex
 	if (lastAccessibleRollInFrame < selection.rollIndex) {
 		selection = selection.copy(rollIndex = lastAccessibleRollInFrame)
+	}
+
+
+	val frames = if (frames.doesRollExistInFrame(selection.frameIndex, selection.rollIndex)) {
+		this.frames
+	} else {frames.toMutableList().also {
+			it.guaranteeRollExists(
+				frameIndex = selection.frameIndex,
+				rollIndex = selection.rollIndex,
+			)
+		}
 	}
 
 	return copy(

--- a/android/feature/gameseditor/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/ui/frameeditor/FrameEditor.kt
+++ b/android/feature/gameseditor/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/ui/frameeditor/FrameEditor.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -49,9 +48,13 @@ fun FrameEditor(
 			verticalAlignment = Alignment.CenterVertically,
 			modifier = Modifier
 				.fillMaxWidth()
-				.pointerInput(state.downedPins) {
+				.pointerInput(state.isEnabled, state.downedPins) {
 					awaitEachGesture {
 						awaitFirstDown()
+
+						onAction(FrameEditorUiAction.FrameEditorInteractionStarted)
+						if (!state.isEnabled) return@awaitEachGesture
+
 						do {
 							val event: PointerEvent = awaitPointerEvent()
 							event.changes.forEach {
@@ -69,7 +72,9 @@ fun FrameEditor(
 										toggledPins = toggledPins
 											.toMutableSet()
 											.apply { add(pin) }
-										downedPins = downedPins.toMutableSet().toggle(pin)
+										downedPins = downedPins
+											.toMutableSet()
+											.toggle(pin)
 									}
 								}
 							}
@@ -124,6 +129,7 @@ private fun FrameEditorPreview() {
 			state = state,
 			onAction = {
 				when (it) {
+					FrameEditorUiAction.FrameEditorInteractionStarted -> Unit
 					is FrameEditorUiAction.DownedPinsChanged -> state = state.copy(downedPins = it.downedPins)
 				}
 			},

--- a/android/feature/gameseditor/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/ui/frameeditor/FrameEditorUi.kt
+++ b/android/feature/gameseditor/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gameseditor/ui/frameeditor/FrameEditorUi.kt
@@ -3,10 +3,12 @@ package ca.josephroque.bowlingcompanion.feature.gameseditor.ui.frameeditor
 import ca.josephroque.bowlingcompanion.core.model.Pin
 
 data class FrameEditorUiState(
+	val isEnabled: Boolean = false,
 	val lockedPins: Set<Pin> = emptySet(),
 	val downedPins: Set<Pin> = emptySet(),
 )
 
 sealed interface FrameEditorUiAction {
+	data object FrameEditorInteractionStarted: FrameEditorUiAction
 	data class DownedPinsChanged(val downedPins: Set<Pin>): FrameEditorUiAction
 }

--- a/android/feature/gameseditor/ui/src/main/res/values/strings.xml
+++ b/android/feature/gameseditor/ui/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+	<string name="game_editor_locked">Locked! Unlock your game first</string>
+
 	<string name="game_editor_foul">Foul?</string>
 
 	<string name="game_editor_next_roll">Go to Ball %1$d</string>

--- a/ios/Approach/Sources/FramesRepositoryInterface/Models/Frame+Edit.swift
+++ b/ios/Approach/Sources/FramesRepositoryInterface/Models/Frame+Edit.swift
@@ -81,27 +81,14 @@ extension Frame.Edit {
 	}
 
 	public mutating func setBowlingBall(_ bowlingBall: Gear.Summary?, forRoll rollIndex: Int) {
-		guaranteeRollExists(upTo: rollIndex)
 		rolls[rollIndex].bowlingBall = bowlingBall
 	}
 
 	public mutating func setDidFoul(_ didFoul: Bool, forRoll rollIndex: Int) {
-		guaranteeRollExists(upTo: rollIndex)
 		rolls[rollIndex].roll.didFoul = didFoul
 	}
 
-	public mutating func toggle(_ pin: Pin, rollIndex: Int, newValue: Bool? = nil) {
-		guaranteeRollExists(upTo: rollIndex)
-		rolls[rollIndex].toggle(pin, newValue: newValue)
-
-		// Raise pins in subsequent rolls
-		for roll in (rollIndex + 1..<rolls.endIndex) {
-			rolls[roll].toggle(pin, newValue: false)
-		}
-	}
-
 	public mutating func setDownedPins(rollIndex: Int, to downedPins: Set<Pin>) {
-		guaranteeRollExists(upTo: rollIndex)
 		rolls[rollIndex].roll.pinsDowned = downedPins
 		for roll in (rollIndex + 1..<rolls.endIndex) {
 			rolls[roll].roll.pinsDowned.subtract(downedPins)
@@ -112,11 +99,6 @@ extension Frame.Edit {
 		while rolls.count < index + 1 {
 			rolls.append(.init(index: rolls.count, roll: .default, bowlingBall: nil))
 		}
-	}
-
-	public mutating func roll(at index: Int) -> Frame.Roll {
-		guaranteeRollExists(upTo: index)
-		return rolls[index].roll
 	}
 
 	public func deck(forRoll index: Int) -> Set<Pin> {


### PR DESCRIPTION
Fixes #412

- Prevents edits to the game when it is locked.
- Shows a SnackBar when the user tries to take an action on a locked game