### PR TITLE
Allow nullable alley ID and save lanes to alley only when alley is saved

### DIFF
--- a/android/core/database/schemas/ca.josephroque.bowlingcompanion.core.database.ApproachDatabase/1.json
+++ b/android/core/database/schemas/ca.josephroque.bowlingcompanion.core.database.ApproachDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "80a3312086226e4a0fc1d24fde8f1d90",
+    "identityHash": "47f59e32b0e248651178d53f5ed098c6",
     "entities": [
       {
         "tableName": "bowlers",
@@ -581,7 +581,7 @@
       },
       {
         "tableName": "lanes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `alley_id` BLOB DEFAULT NULL, `label` TEXT NOT NULL, `position` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`alley_id`) REFERENCES `alleys`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `alley_id` BLOB, `label` TEXT NOT NULL, `position` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`alley_id`) REFERENCES `alleys`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -593,8 +593,7 @@
             "fieldPath": "alleyId",
             "columnName": "alley_id",
             "affinity": "BLOB",
-            "notNull": false,
-            "defaultValue": "NULL"
+            "notNull": false
           },
           {
             "fieldPath": "label",
@@ -1501,7 +1500,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '80a3312086226e4a0fc1d24fde8f1d90')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '47f59e32b0e248651178d53f5ed098c6')"
     ]
   }
 }

--- a/android/core/database/src/main/java/ca/josephroque/bowlingcompanion/core/database/dao/LaneDao.kt
+++ b/android/core/database/src/main/java/ca/josephroque/bowlingcompanion/core/database/dao/LaneDao.kt
@@ -2,6 +2,7 @@ package ca.josephroque.bowlingcompanion.core.database.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import ca.josephroque.bowlingcompanion.core.database.model.GameLaneCrossRef
@@ -55,6 +56,6 @@ abstract class LaneDao {
 	@Query("DELETE FROM lanes WHERE alley_id = :alleyId")
 	abstract fun deleteAlleyLanes(alleyId: UUID)
 
-	@Insert
+	@Insert(onConflict = OnConflictStrategy.REPLACE)
 	abstract fun insertAll(lanes: List<LaneEntity>)
 }

--- a/android/core/database/src/main/java/ca/josephroque/bowlingcompanion/core/database/model/LaneEntity.kt
+++ b/android/core/database/src/main/java/ca/josephroque/bowlingcompanion/core/database/model/LaneEntity.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 )
 data class LaneEntity(
 	@PrimaryKey @ColumnInfo(name = "id", index = true) val id: UUID,
-	@ColumnInfo(name = "alley_id", index = true, defaultValue = "NULL") val alleyId: UUID?,
+	@ColumnInfo(name = "alley_id", index = true) val alleyId: UUID?,
 	@ColumnInfo(name = "label") val label: String,
 	@ColumnInfo(name = "position") val position: LanePosition,
 )


### PR DESCRIPTION
Fixes #428 

Issue was twofold:
- Lanes were attempting to be saved with null alley ID, but database schema did not allow for the value to be nullable
- Alleys were setting their IDs to lanes when the lanes were passed back to alleys being created, before the alley was persisted, and so the foreign key check failed