### PR TITLE
Discard Changes Modal

### DIFF
--- a/android/core/designsystem/src/main/java/ca/josephroque/bowlingcompanion/core/designsystem/components/DiscardChangesDialog.kt
+++ b/android/core/designsystem/src/main/java/ca/josephroque/bowlingcompanion/core/designsystem/components/DiscardChangesDialog.kt
@@ -1,0 +1,30 @@
+package ca.josephroque.bowlingcompanion.core.designsystem.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import ca.josephroque.bowlingcompanion.core.designsystem.R
+
+@Composable
+fun DiscardChangesDialog(
+	onDiscardChanges: () -> Unit,
+	onDismiss: () -> Unit,
+) {
+	AlertDialog(
+		onDismissRequest = onDismiss,
+		title = { Text(text = stringResource(R.string.discard_changes_dialog_title)) },
+		text = { Text(text = stringResource(R.string.discard_changes_dialog_message)) },
+		confirmButton = {
+			TextButton(onClick = onDiscardChanges) {
+				Text(text = stringResource(R.string.action_discard))
+			}
+		},
+		dismissButton = {
+			TextButton(onClick = onDismiss) {
+				Text(text = stringResource(R.string.action_keep_editing))
+			}
+		}
+	)
+}

--- a/android/core/designsystem/src/main/res/values/strings.xml
+++ b/android/core/designsystem/src/main/res/values/strings.xml
@@ -8,11 +8,16 @@
 	<string name="delete_dialog_title">Are you sure you want to delete %1$s?</string>
 	<string name="delete_dialog_message">It will be deleted from all your games. It cannot be recovered.</string>
 
+	<string name="discard_changes_dialog_title">Discard changes?</string>
+	<string name="discard_changes_dialog_message">Are you sure you want to discard your changes?</string>
+
 	<string name="action_confirm">Confirm</string>
 	<string name="action_cancel">Cancel</string>
 	<string name="action_save">Save</string>
 	<string name="action_delete">Delete</string>
 	<string name="action_dismiss">Dismiss</string>
+	<string name="action_discard">Discard</string>
+	<string name="action_keep_editing">Keep Editing</string>
 	<string name="action_archive">Archive</string>
 	<string name="action_manage">Manage</string>
 	<string name="action_send_email">Send Email</string>

--- a/android/feature/alleyform/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/AlleyFormScreen.kt
+++ b/android/feature/alleyform/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/AlleyFormScreen.kt
@@ -1,5 +1,6 @@
 package ca.josephroque.bowlingcompanion.feature.alleyform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -18,6 +19,7 @@ import ca.josephroque.bowlingcompanion.core.common.navigation.NavResultCallback
 import ca.josephroque.bowlingcompanion.feature.alleyform.ui.AlleyForm
 import ca.josephroque.bowlingcompanion.feature.alleyform.ui.AlleyFormTopBar
 import ca.josephroque.bowlingcompanion.feature.alleyform.ui.AlleyFormTopBarUiState
+import ca.josephroque.bowlingcompanion.feature.alleyform.ui.AlleyFormUiAction
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -63,6 +65,10 @@ private fun AlleyFormScreen(
 ) {
 	LaunchedEffect(Unit) {
 		onAction(AlleyFormScreenUiAction.LoadAlley)
+	}
+
+	BackHandler {
+		onAction(AlleyFormScreenUiAction.AlleyForm(AlleyFormUiAction.BackClicked))
 	}
 
 	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/android/feature/alleyform/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/AlleyFormScreenUi.kt
+++ b/android/feature/alleyform/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/AlleyFormScreenUi.kt
@@ -7,14 +7,23 @@ import ca.josephroque.bowlingcompanion.feature.alleyform.ui.AlleyFormUiState
 import java.util.UUID
 
 sealed interface AlleyFormScreenUiState {
-	data object Loading: AlleyFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: AlleyFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Create(
 		val form: AlleyFormUiState,
 		val topBar: AlleyFormTopBarUiState,
 	): AlleyFormScreenUiState {
-		fun isSavable(): Boolean =
+		override fun isSavable(): Boolean =
 			form.name.isNotBlank()
+
+		override fun hasAnyChanges(): Boolean =
+			form != AlleyFormUiState()
 	}
 
 	data class Edit(
@@ -22,8 +31,11 @@ sealed interface AlleyFormScreenUiState {
 		val form: AlleyFormUiState,
 		val topBar: AlleyFormTopBarUiState,
 	): AlleyFormScreenUiState {
-		fun isSavable(): Boolean =
+		override fun isSavable(): Boolean =
 			form.name.isNotBlank() && form.updatedModel(existing = initialValue) != initialValue
+
+		override fun hasAnyChanges(): Boolean =
+			form.updatedModel(existing = initialValue) != initialValue
 	}
 }
 

--- a/android/feature/alleyform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/ui/AlleyForm.kt
+++ b/android/feature/alleyform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/ui/AlleyForm.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.designsystem.R as RCoreDesign
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormRadioGroup
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormSection
@@ -37,6 +38,13 @@ fun AlleyForm(
 	onAction: (AlleyFormUiAction) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(AlleyFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(AlleyFormUiAction.CancelDiscardChangesClicked) },
+		)
+	}
+
 	Column(
 		modifier = modifier
 			.verticalScroll(rememberScrollState())

--- a/android/feature/alleyform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/ui/AlleyFormUi.kt
+++ b/android/feature/alleyform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/alleyform/ui/AlleyFormUi.kt
@@ -8,16 +8,17 @@ import ca.josephroque.bowlingcompanion.core.model.AlleyPinFall
 import ca.josephroque.bowlingcompanion.core.model.LaneListItem
 
 data class AlleyFormUiState(
-	val name: String,
-	@StringRes val nameErrorId: Int?,
-	val material: AlleyMaterial?,
-	val pinFall: AlleyPinFall?,
-	val mechanism: AlleyMechanism?,
-	val pinBase: AlleyPinBase?,
-	val lanes: List<LaneListItem>,
+	val name: String = "",
+	@StringRes val nameErrorId: Int? = null,
+	val material: AlleyMaterial? = null,
+	val pinFall: AlleyPinFall? = null,
+	val mechanism: AlleyMechanism? = null,
+	val pinBase: AlleyPinBase? = null,
+	val lanes: List<LaneListItem> = emptyList(),
 
-	val isShowingDeleteDialog: Boolean,
-	val isDeleteButtonEnabled: Boolean,
+	val isShowingDeleteDialog: Boolean = false,
+	val isDeleteButtonEnabled: Boolean = false,
+	val isShowingDiscardChangesDialog: Boolean = false,
 )
 
 sealed interface AlleyFormUiAction {
@@ -27,6 +28,9 @@ sealed interface AlleyFormUiAction {
 	data object DeleteClicked: AlleyFormUiAction
 	data object ConfirmDeleteClicked: AlleyFormUiAction
 	data object DismissDeleteClicked: AlleyFormUiAction
+
+	data object DiscardChangesClicked: AlleyFormUiAction
+	data object CancelDiscardChangesClicked: AlleyFormUiAction
 
 	data object ManageLanesClicked: AlleyFormUiAction
 

--- a/android/feature/avatarform/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/AvatarFormScreen.kt
+++ b/android/feature/avatarform/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/AvatarFormScreen.kt
@@ -1,5 +1,6 @@
 package ca.josephroque.bowlingcompanion.feature.avatarform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -17,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import ca.josephroque.bowlingcompanion.core.model.Avatar
 import ca.josephroque.bowlingcompanion.feature.avatarform.ui.AvatarForm
 import ca.josephroque.bowlingcompanion.feature.avatarform.ui.AvatarFormTopBar
+import ca.josephroque.bowlingcompanion.feature.avatarform.ui.AvatarFormUiAction
 import kotlinx.coroutines.launch
 
 @Composable
@@ -56,6 +58,10 @@ private fun AvatarFormScreen(
 ) {
 	LaunchedEffect(Unit) {
 		onAction(AvatarFormScreenUiAction.LoadAvatar)
+	}
+
+	BackHandler {
+		onAction(AvatarFormScreenUiAction.AvatarFormAction(AvatarFormUiAction.BackClicked))
 	}
 
 	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/android/feature/avatarform/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/AvatarFormScreenUi.kt
+++ b/android/feature/avatarform/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/AvatarFormScreenUi.kt
@@ -5,11 +5,21 @@ import ca.josephroque.bowlingcompanion.feature.avatarform.ui.AvatarFormUiAction
 import ca.josephroque.bowlingcompanion.feature.avatarform.ui.AvatarFormUiState
 
 sealed interface AvatarFormScreenUiState {
-	data object Loading: AvatarFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: AvatarFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Loaded(
 		val form: AvatarFormUiState,
-	): AvatarFormScreenUiState
+	): AvatarFormScreenUiState {
+		override fun isSavable(): Boolean = true
+		override fun hasAnyChanges(): Boolean =
+			form.avatar != form.initialValue
+	}
 }
 
 sealed interface AvatarFormScreenUiAction {

--- a/android/feature/avatarform/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/AvatarFormViewModel.kt
+++ b/android/feature/avatarform/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/AvatarFormViewModel.kt
@@ -51,8 +51,10 @@ class AvatarFormViewModel @Inject constructor(
 
 	private fun handleAvatarFormAction(action: AvatarFormUiAction) {
 		when (action) {
-			AvatarFormUiAction.BackClicked -> sendEvent(AvatarFormScreenEvent.Dismissed(existingAvatar))
+			AvatarFormUiAction.BackClicked -> handleBackClicked()
 			AvatarFormUiAction.DoneClicked -> saveAvatar()
+			AvatarFormUiAction.DiscardChangesClicked -> dismissEditor()
+			AvatarFormUiAction.CancelDiscardChangesClicked -> setDiscardChangesDialog(isVisible = false)
 			is AvatarFormUiAction.PrimaryColorClicked -> onPrimaryColorClicked()
 			is AvatarFormUiAction.SecondaryColorClicked -> onSecondaryColorClicked()
 			is AvatarFormUiAction.RandomizeColorsClicked -> onRandomizeColorsClicked()
@@ -67,13 +69,34 @@ class AvatarFormViewModel @Inject constructor(
 		}
 	}
 
+	private fun dismissEditor() {
+		sendEvent(AvatarFormScreenEvent.Dismissed(existingAvatar))
+	}
+
 	private fun loadAvatar() {
 		_uiState.value = AvatarFormScreenUiState.Loaded(
 			form = AvatarFormUiState(
+				initialValue = existingAvatar,
 				avatar = existingAvatar,
 				colorPickerState = ColorPickerUiState.Hidden,
+				isShowingDiscardChangesDialog = false,
 			),
 		)
+	}
+
+	private fun handleBackClicked() {
+		if (_uiState.value.hasAnyChanges()) {
+			setDiscardChangesDialog(isVisible = true)
+		} else {
+			dismissEditor()
+		}
+	}
+
+	private fun setDiscardChangesDialog(isVisible: Boolean) {
+		val state = getFormUiState() ?: return
+		setFormUiState(state.copy(
+			isShowingDiscardChangesDialog = isVisible,
+		))
 	}
 
 	private fun saveAvatar() {

--- a/android/feature/avatarform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/ui/AvatarForm.kt
+++ b/android/feature/avatarform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/ui/AvatarForm.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.model.Avatar
 import ca.josephroque.bowlingcompanion.core.model.ui.AvatarImage
 import ca.josephroque.bowlingcompanion.core.model.ui.toComposeColor
@@ -36,6 +37,13 @@ fun AvatarForm(
 	onAction: (AvatarFormUiAction) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(AvatarFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(AvatarFormUiAction.CancelDiscardChangesClicked) },
+		)
+	}
+
 	ColorPicker(
 		state = state.colorPickerState,
 		onAction = { onAction(AvatarFormUiAction.ColorPickerAction(it)) },
@@ -131,8 +139,10 @@ private fun AvatarFormPreview() {
 	Surface {
 		AvatarForm(
 			state = AvatarFormUiState(
+				initialValue = Avatar.default(),
 				avatar = Avatar.default(),
 				colorPickerState = ColorPickerUiState.Hidden,
+				isShowingDiscardChangesDialog = false,
 			),
 			onAction = {},
 		)

--- a/android/feature/avatarform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/ui/AvatarFormUi.kt
+++ b/android/feature/avatarform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/avatarform/ui/AvatarFormUi.kt
@@ -4,8 +4,10 @@ import androidx.compose.ui.graphics.Color
 import ca.josephroque.bowlingcompanion.core.model.Avatar
 
 data class AvatarFormUiState(
+	val initialValue: Avatar,
 	val avatar: Avatar,
-	val colorPickerState: ColorPickerUiState
+	val colorPickerState: ColorPickerUiState,
+	val isShowingDiscardChangesDialog: Boolean,
 )
 
 sealed interface AvatarFormUiAction {
@@ -15,6 +17,9 @@ sealed interface AvatarFormUiAction {
 	data object PrimaryColorClicked: AvatarFormUiAction
 	data object SecondaryColorClicked: AvatarFormUiAction
 	data object RandomizeColorsClicked: AvatarFormUiAction
+
+	data object DiscardChangesClicked: AvatarFormUiAction
+	data object CancelDiscardChangesClicked: AvatarFormUiAction
 
 	data class LabelChanged(val label: String): AvatarFormUiAction
 	data class ColorPickerAction(val event: ColorPickerUiAction): AvatarFormUiAction

--- a/android/feature/bowlerform/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/BowlerFormScreen.kt
+++ b/android/feature/bowlerform/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/BowlerFormScreen.kt
@@ -1,7 +1,10 @@
 package ca.josephroque.bowlingcompanion.feature.bowlerform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -14,6 +17,7 @@ import androidx.lifecycle.lifecycleScope
 import ca.josephroque.bowlingcompanion.feature.bowlerform.ui.BowlerForm
 import ca.josephroque.bowlingcompanion.feature.bowlerform.ui.BowlerFormTopBar
 import ca.josephroque.bowlingcompanion.feature.bowlerform.ui.BowlerFormTopBarUiState
+import ca.josephroque.bowlingcompanion.feature.bowlerform.ui.BowlerFormUiAction
 import kotlinx.coroutines.launch
 
 @Composable
@@ -44,6 +48,7 @@ internal fun BowlerFormRoute(
 	)
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BowlerFormScreen(
 	state: BowlerFormScreenUiState,
@@ -54,6 +59,12 @@ private fun BowlerFormScreen(
 		onAction(BowlerFormScreenUiAction.LoadBowler)
 	}
 
+	BackHandler {
+		onAction(BowlerFormScreenUiAction.BowlerFormAction(BowlerFormUiAction.BackClicked))
+	}
+
+	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
 	Scaffold(
 		topBar = {
 			BowlerFormTopBar(
@@ -63,6 +74,7 @@ private fun BowlerFormScreen(
 					is BowlerFormScreenUiState.Edit -> state.topBar
 			  },
 				onAction = { onAction(BowlerFormScreenUiAction.BowlerFormAction(it)) },
+				scrollBehavior = scrollBehavior,
 			)
 		},
 	) { padding ->

--- a/android/feature/bowlerform/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/BowlerFormScreenUi.kt
+++ b/android/feature/bowlerform/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/BowlerFormScreenUi.kt
@@ -7,14 +7,23 @@ import ca.josephroque.bowlingcompanion.feature.bowlerform.ui.BowlerFormUiState
 import java.util.UUID
 
 sealed interface BowlerFormScreenUiState {
-	data object Loading: BowlerFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: BowlerFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Create(
 		val form: BowlerFormUiState,
 		val topBar: BowlerFormTopBarUiState,
 	): BowlerFormScreenUiState {
-		fun isSavable(): Boolean =
+		override fun isSavable(): Boolean =
 			form.name.isNotBlank()
+
+		override fun hasAnyChanges(): Boolean =
+			form != BowlerFormUiState()
 	}
 
 	data class Edit(
@@ -22,12 +31,15 @@ sealed interface BowlerFormScreenUiState {
 		val form: BowlerFormUiState,
 		val topBar: BowlerFormTopBarUiState,
 	): BowlerFormScreenUiState {
-		fun isSavable(): Boolean =
-			form.name.isNotBlank() && form.update(id = initialValue.id) != initialValue
+		override fun isSavable(): Boolean =
+			form.name.isNotBlank() && form.updatedModel(id = initialValue.id) != initialValue
+
+		override fun hasAnyChanges(): Boolean =
+			form.updatedModel(id = initialValue.id) != initialValue
 	}
 }
 
-fun BowlerFormUiState.update(id: UUID): BowlerUpdate = BowlerUpdate(
+fun BowlerFormUiState.updatedModel(id: UUID): BowlerUpdate = BowlerUpdate(
 	id = id,
 	name = name,
 )

--- a/android/feature/bowlerform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/ui/BowlerForm.kt
+++ b/android/feature/bowlerform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/ui/BowlerForm.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import ca.josephroque.bowlingcompanion.core.designsystem.R as RCoreDesign
 import ca.josephroque.bowlingcompanion.core.designsystem.components.ArchiveDialog
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormSection
 
 @Composable
@@ -38,6 +39,13 @@ fun BowlerForm(
 			itemName = state.name,
 			onArchive = { onAction(BowlerFormUiAction.ConfirmArchiveClicked) },
 			onDismiss = { onAction(BowlerFormUiAction.DismissArchiveClicked) },
+		)
+	}
+
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(BowlerFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(BowlerFormUiAction.CancelDiscardChangesClicked) },
 		)
 	}
 

--- a/android/feature/bowlerform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/ui/BowlerFormTopBar.kt
+++ b/android/feature/bowlerform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/ui/BowlerFormTopBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -18,11 +19,13 @@ import ca.josephroque.bowlingcompanion.core.model.BowlerKind
 fun BowlerFormTopBar(
 	state: BowlerFormTopBarUiState,
 	onAction: (BowlerFormUiAction) -> Unit,
+	scrollBehavior: TopAppBarScrollBehavior,
 ) {
 	TopAppBar(
 		title = { Title(state) },
 		navigationIcon = { BackButton(onClick = { onAction(BowlerFormUiAction.BackClicked) }) },
 		actions = { Actions(onAction) },
+		scrollBehavior = scrollBehavior,
 	)
 }
 

--- a/android/feature/bowlerform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/ui/BowlerFormUi.kt
+++ b/android/feature/bowlerform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/bowlerform/ui/BowlerFormUi.kt
@@ -4,15 +4,19 @@ import androidx.annotation.StringRes
 import ca.josephroque.bowlingcompanion.core.model.BowlerKind
 
 data class BowlerFormUiState(
-	val name: String,
-	@StringRes val nameErrorId: Int?,
-	val isShowingArchiveDialog: Boolean,
-	val isArchiveButtonEnabled: Boolean,
+	val name: String = "",
+	@StringRes val nameErrorId: Int? = null,
+	val isShowingArchiveDialog: Boolean = false,
+	val isArchiveButtonEnabled: Boolean = false,
+	val isShowingDiscardChangesDialog: Boolean = false,
 )
 
 sealed interface BowlerFormUiAction {
 	data object BackClicked: BowlerFormUiAction
 	data object DoneClicked: BowlerFormUiAction
+
+	data object DiscardChangesClicked: BowlerFormUiAction
+	data object CancelDiscardChangesClicked: BowlerFormUiAction
 
 	data object ArchiveClicked: BowlerFormUiAction
 	data object ConfirmArchiveClicked: BowlerFormUiAction

--- a/android/feature/gearform/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/GearFormScreen.kt
+++ b/android/feature/gearform/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/GearFormScreen.kt
@@ -1,5 +1,6 @@
 package ca.josephroque.bowlingcompanion.feature.gearform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -19,6 +20,7 @@ import ca.josephroque.bowlingcompanion.core.model.Avatar
 import ca.josephroque.bowlingcompanion.feature.gearform.ui.GearForm
 import ca.josephroque.bowlingcompanion.feature.gearform.ui.GearFormTopBar
 import ca.josephroque.bowlingcompanion.feature.gearform.ui.GearFormTopBarUiState
+import ca.josephroque.bowlingcompanion.feature.gearform.ui.GearFormUiAction
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -69,6 +71,10 @@ private fun GearFormScreen(
 ) {
 	LaunchedEffect(Unit) {
 		onAction(GearFormScreenUiAction.LoadGear)
+	}
+
+	BackHandler {
+		onAction(GearFormScreenUiAction.GearFormAction(GearFormUiAction.BackClicked))
 	}
 
 	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/android/feature/gearform/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/GearFormScreenUi.kt
+++ b/android/feature/gearform/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/GearFormScreenUi.kt
@@ -8,14 +8,23 @@ import ca.josephroque.bowlingcompanion.feature.gearform.ui.GearFormUiState
 import java.util.UUID
 
 sealed interface GearFormScreenUiState {
-	data object Loading: GearFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: GearFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Create(
 		val form: GearFormUiState,
 		val topBar: GearFormTopBarUiState,
 	): GearFormScreenUiState {
-		fun isSavable(): Boolean =
+		override fun isSavable(): Boolean =
 			form.name.isNotBlank()
+
+		override fun hasAnyChanges(): Boolean =
+			form != GearFormUiState()
 	}
 
 	data class Edit(
@@ -23,8 +32,11 @@ sealed interface GearFormScreenUiState {
 		val form: GearFormUiState,
 		val topBar: GearFormTopBarUiState,
 	): GearFormScreenUiState {
-		fun isSavable(): Boolean =
+		override fun isSavable(): Boolean =
 			form.name.isNotBlank() && form.updatedModel(existing = initialValue) != initialValue
+
+		override fun hasAnyChanges(): Boolean =
+			form.updatedModel(existing = initialValue) != initialValue
 	}
 }
 

--- a/android/feature/gearform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/ui/GearForm.kt
+++ b/android/feature/gearform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/ui/GearForm.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import ca.josephroque.bowlingcompanion.core.designsystem.R as RCoreDesign
 import ca.josephroque.bowlingcompanion.core.designsystem.components.DeleteDialog
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormSection
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.PickableResourceCard
 import ca.josephroque.bowlingcompanion.core.model.ui.AvatarImage
@@ -41,6 +42,13 @@ fun GearForm(
 			itemName = state.name,
 			onDelete = { onAction(GearFormUiAction.ConfirmDeleteClicked) },
 			onDismiss = { onAction(GearFormUiAction.DismissDeleteClicked) },
+		)
+	}
+
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(GearFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(GearFormUiAction.CancelDiscardChangesClicked) },
 		)
 	}
 

--- a/android/feature/gearform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/ui/GearFormUi.kt
+++ b/android/feature/gearform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/gearform/ui/GearFormUi.kt
@@ -6,13 +6,14 @@ import ca.josephroque.bowlingcompanion.core.model.BowlerDetails
 import ca.josephroque.bowlingcompanion.core.model.GearKind
 
 data class GearFormUiState(
-	val name: String,
-	val kind: GearKind,
-	@StringRes val nameErrorId: Int?,
-	val owner: BowlerDetails?,
-	val avatar: Avatar,
-	val isShowingDeleteDialog: Boolean,
-	val isDeleteButtonEnabled: Boolean,
+	val name: String = "",
+	val kind: GearKind = GearKind.BOWLING_BALL,
+	@StringRes val nameErrorId: Int? = null,
+	val owner: BowlerDetails? = null,
+	val avatar: Avatar = Avatar.default(),
+	val isShowingDeleteDialog: Boolean = false,
+	val isDeleteButtonEnabled: Boolean = false,
+	val isShowingDiscardChangesDialog: Boolean = false,
 )
 
 sealed interface GearFormUiAction {
@@ -22,6 +23,9 @@ sealed interface GearFormUiAction {
 	data object DeleteClicked: GearFormUiAction
 	data object ConfirmDeleteClicked: GearFormUiAction
 	data object DismissDeleteClicked: GearFormUiAction
+
+	data object DiscardChangesClicked: GearFormUiAction
+	data object CancelDiscardChangesClicked: GearFormUiAction
 
 	data object AvatarClicked: GearFormUiAction
 	data object OwnerClicked: GearFormUiAction

--- a/android/feature/laneform/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/LaneFormScreen.kt
+++ b/android/feature/laneform/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/LaneFormScreen.kt
@@ -1,5 +1,6 @@
 package ca.josephroque.bowlingcompanion.feature.laneform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,6 +20,7 @@ import androidx.lifecycle.lifecycleScope
 import ca.josephroque.bowlingcompanion.feature.laneform.ui.LaneForm
 import ca.josephroque.bowlingcompanion.feature.laneform.ui.LaneFormFloatingActionButton
 import ca.josephroque.bowlingcompanion.feature.laneform.ui.LaneFormTopBar
+import ca.josephroque.bowlingcompanion.feature.laneform.ui.LaneFormUiAction
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -61,6 +63,10 @@ private fun LaneFormScreen(
 
 	LaunchedEffect(Unit) {
 		onAction(LaneFormScreenUiAction.LoadLanes)
+	}
+
+	BackHandler {
+		onAction(LaneFormScreenUiAction.LaneForm(LaneFormUiAction.BackClicked))
 	}
 
 	Scaffold(

--- a/android/feature/laneform/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/LaneFormScreenUi.kt
+++ b/android/feature/laneform/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/LaneFormScreenUi.kt
@@ -5,11 +5,22 @@ import ca.josephroque.bowlingcompanion.feature.laneform.ui.LaneFormUiState
 import java.util.UUID
 
 sealed interface LaneFormScreenUiState {
-	data object Loading: LaneFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: LaneFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Loaded(
 		val laneForm: LaneFormUiState,
-	): LaneFormScreenUiState
+	): LaneFormScreenUiState {
+		override fun isSavable(): Boolean = true
+
+		override fun hasAnyChanges(): Boolean =
+			laneForm.hasAnyChanges()
+	}
 }
 
 sealed interface LaneFormScreenUiAction {

--- a/android/feature/laneform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/ui/LaneForm.kt
+++ b/android/feature/laneform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/ui/LaneForm.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.designsystem.components.Tip
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.Stepper
 import ca.josephroque.bowlingcompanion.core.designsystem.components.list.footer
@@ -34,6 +35,13 @@ fun LaneForm(
 	state: LaneFormUiState,
 	onAction: (LaneFormUiAction) -> Unit,
 ) {
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(LaneFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(LaneFormUiAction.CancelDiscardChangesClicked) },
+		)
+	}
+
 	state.laneLabel?.let { dialog ->
 		LaneLabelDialog(
 			state = dialog,

--- a/android/feature/laneform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/ui/LaneFormUi.kt
+++ b/android/feature/laneform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/laneform/ui/LaneFormUi.kt
@@ -6,16 +6,24 @@ import java.util.UUID
 
 data class LaneFormUiState(
 	val isShowingSwipeToEditTip: Boolean = false,
+	val existingLanes: List<LaneListItem> = emptyList(),
 	val lanes: List<LaneListItem> = emptyList(),
 	val addLanes: AddLanesDialogUiState? = null,
 	val laneLabel: LaneLabelDialogUiState? = null,
-)
+	val isShowingDiscardChangesDialog: Boolean = false,
+) {
+	fun hasAnyChanges(): Boolean =
+		existingLanes != lanes
+}
 
 sealed interface LaneFormUiAction {
 	data object BackClicked: LaneFormUiAction
 	data object DoneClicked: LaneFormUiAction
 	data object SwipeToEditTipDismissed: LaneFormUiAction
 	data object AddLanesClicked: LaneFormUiAction
+
+	data object DiscardChangesClicked: LaneFormUiAction
+	data object CancelDiscardChangesClicked: LaneFormUiAction
 
 	data class AddLanesDialog(val action: AddLanesDialogUiAction): LaneFormUiAction
 	data class LaneLabelDialog(val action: LaneLabelDialogUiAction): LaneFormUiAction

--- a/android/feature/leagueform/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/LeagueFormScreen.kt
+++ b/android/feature/leagueform/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/LeagueFormScreen.kt
@@ -1,5 +1,6 @@
 package ca.josephroque.bowlingcompanion.feature.leagueform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -17,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import ca.josephroque.bowlingcompanion.feature.leagueform.ui.LeagueForm
 import ca.josephroque.bowlingcompanion.feature.leagueform.ui.LeagueFormTopBar
 import ca.josephroque.bowlingcompanion.feature.leagueform.ui.LeagueFormTopBarUiState
+import ca.josephroque.bowlingcompanion.feature.leagueform.ui.LeagueFormUiAction
 import kotlinx.coroutines.launch
 
 @Composable
@@ -56,6 +58,10 @@ internal fun LeagueFormScreen(
 ) {
 	LaunchedEffect(Unit) {
 		onAction(LeagueFormScreenUiAction.LoadLeague)
+	}
+
+	BackHandler {
+		onAction(LeagueFormScreenUiAction.LeagueForm(LeagueFormUiAction.BackClicked))
 	}
 
 	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/android/feature/leagueform/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/LeagueFormScreenUi.kt
+++ b/android/feature/leagueform/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/LeagueFormScreenUi.kt
@@ -8,14 +8,23 @@ import ca.josephroque.bowlingcompanion.feature.leagueform.ui.LeagueFormUiState
 import java.util.UUID
 
 sealed interface LeagueFormScreenUiState {
-	data object Loading: LeagueFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: LeagueFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Create(
 		val form: LeagueFormUiState,
 		val topBar: LeagueFormTopBarUiState,
 	): LeagueFormScreenUiState {
-		fun isSavable(): Boolean =
+		override fun isSavable(): Boolean =
 			form.name.isNotBlank()
+
+		override fun hasAnyChanges(): Boolean =
+			form != LeagueFormUiState()
 	}
 
 	data class Edit(
@@ -23,12 +32,15 @@ sealed interface LeagueFormScreenUiState {
 		val form: LeagueFormUiState,
 		val topBar: LeagueFormTopBarUiState,
 	): LeagueFormScreenUiState {
-		fun isSavable(): Boolean =
-			form.name.isNotBlank() && form.update(id = initialValue.id) != initialValue
+		override fun isSavable(): Boolean =
+			form.name.isNotBlank() && form.updatedModel(id = initialValue.id) != initialValue
+
+		override fun hasAnyChanges(): Boolean =
+			form.updatedModel(id = initialValue.id) != initialValue
 	}
 }
 
-fun LeagueFormUiState.update(id: UUID): LeagueUpdate = LeagueUpdate(
+fun LeagueFormUiState.updatedModel(id: UUID): LeagueUpdate = LeagueUpdate(
 	id = id,
 	name = name,
 	additionalGames = when (includeAdditionalPinFall) {

--- a/android/feature/leagueform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/ui/LeagueForm.kt
+++ b/android/feature/leagueform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/ui/LeagueForm.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import ca.josephroque.bowlingcompanion.core.designsystem.components.ArchiveDialog
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.designsystem.R as RCoreDesign
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormRadioGroup
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormSection
@@ -44,6 +45,13 @@ fun LeagueForm(
 			itemName = state.name,
 			onArchive = { onAction(LeagueFormUiAction.ConfirmArchiveClicked) },
 			onDismiss = { onAction(LeagueFormUiAction.DismissArchiveClicked) },
+		)
+	}
+
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(LeagueFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(LeagueFormUiAction.CancelDiscardChangesClicked) },
 		)
 	}
 

--- a/android/feature/leagueform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/ui/LeagueFormTopBar.kt
+++ b/android/feature/leagueform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/ui/LeagueFormTopBar.kt
@@ -18,7 +18,7 @@ import ca.josephroque.bowlingcompanion.core.designsystem.components.BackButton
 fun LeagueFormTopBar(
 	state: LeagueFormTopBarUiState,
 	onAction: (LeagueFormUiAction) -> Unit,
-	scrollBehavior: TopAppBarScrollBehavior
+	scrollBehavior: TopAppBarScrollBehavior,
 ) {
 	TopAppBar(
 		title = { Title(state.existingName) },

--- a/android/feature/leagueform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/ui/LeagueFormUi.kt
+++ b/android/feature/leagueform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/leagueform/ui/LeagueFormUi.kt
@@ -19,17 +19,18 @@ data class LeagueFormTopBarUiState(
 )
 
 data class LeagueFormUiState(
-	val name: String,
-	@StringRes val nameErrorId: Int?,
-	val excludeFromStatistics: ExcludeFromStatistics,
-	val includeAdditionalPinFall: IncludeAdditionalPinFall,
-	val additionalPinFall: Int,
-	val additionalGames: Int,
-	val recurrence: LeagueRecurrence? = null,
-	val numberOfGames: Int? = null,
-	val gamesPerSeries: GamesPerSeries? = null,
-	val isShowingArchiveDialog: Boolean,
-	val isArchiveButtonEnabled: Boolean,
+	val name: String = "",
+	@StringRes val nameErrorId: Int? = null,
+	val excludeFromStatistics: ExcludeFromStatistics = ExcludeFromStatistics.INCLUDE,
+	val includeAdditionalPinFall: IncludeAdditionalPinFall = IncludeAdditionalPinFall.NONE,
+	val additionalPinFall: Int = 0,
+	val additionalGames: Int = 0,
+	val recurrence: LeagueRecurrence? = LeagueRecurrence.REPEATING,
+	val numberOfGames: Int? = 4,
+	val gamesPerSeries: GamesPerSeries? = GamesPerSeries.DYNAMIC,
+	val isShowingArchiveDialog: Boolean = false,
+	val isArchiveButtonEnabled: Boolean = false,
+	val isShowingDiscardChangesDialog: Boolean = false,
 )
 
 sealed interface LeagueFormUiAction {
@@ -39,6 +40,9 @@ sealed interface LeagueFormUiAction {
 	data object ArchiveClicked: LeagueFormUiAction
 	data object ConfirmArchiveClicked: LeagueFormUiAction
 	data object DismissArchiveClicked: LeagueFormUiAction
+
+	data object DiscardChangesClicked: LeagueFormUiAction
+	data object CancelDiscardChangesClicked: LeagueFormUiAction
 
 	data class NameChanged(val name: String): LeagueFormUiAction
 	data class RecurrenceChanged(val recurrence: LeagueRecurrence): LeagueFormUiAction

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreen.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreen.kt
@@ -1,5 +1,6 @@
 package ca.josephroque.bowlingcompanion.feature.seriesform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -18,6 +19,7 @@ import ca.josephroque.bowlingcompanion.core.common.navigation.NavResultCallback
 import ca.josephroque.bowlingcompanion.feature.seriesform.ui.SeriesForm
 import ca.josephroque.bowlingcompanion.feature.seriesform.ui.SeriesFormTopBar
 import ca.josephroque.bowlingcompanion.feature.seriesform.ui.SeriesFormTopBarUiState
+import ca.josephroque.bowlingcompanion.feature.seriesform.ui.SeriesFormUiAction
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -63,6 +65,10 @@ private fun SeriesFormScreen(
 ) {
 	LaunchedEffect(Unit) {
 		onAction(SeriesFormScreenUiAction.LoadSeries)
+	}
+
+	BackHandler {
+		onAction(SeriesFormScreenUiAction.SeriesForm(SeriesFormUiAction.BackClicked))
 	}
 
 	val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreenUi.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormScreenUi.kt
@@ -7,18 +7,33 @@ import ca.josephroque.bowlingcompanion.feature.seriesform.ui.SeriesFormUiState
 import java.util.UUID
 
 sealed interface SeriesFormScreenUiState {
-	data object Loading: SeriesFormScreenUiState
+	fun hasAnyChanges(): Boolean
+	fun isSavable(): Boolean
+
+	data object Loading: SeriesFormScreenUiState {
+		override fun hasAnyChanges(): Boolean = false
+		override fun isSavable(): Boolean = false
+	}
 
 	data class Create(
 		val form: SeriesFormUiState,
 		val topBar: SeriesFormTopBarUiState,
-	): SeriesFormScreenUiState
+	): SeriesFormScreenUiState {
+		override fun isSavable(): Boolean = true
+		override fun hasAnyChanges(): Boolean = true
+	}
 
 	data class Edit(
 		val initialValue: SeriesUpdate,
 		val form: SeriesFormUiState,
 		val topBar: SeriesFormTopBarUiState,
-	): SeriesFormScreenUiState
+	): SeriesFormScreenUiState {
+		override fun isSavable(): Boolean =
+			form.updatedModel(existing = initialValue) != initialValue
+
+		override fun hasAnyChanges(): Boolean =
+			form.updatedModel(existing = initialValue) != initialValue
+	}
 }
 
 fun SeriesFormUiState.updatedModel(existing: SeriesUpdate): SeriesUpdate = existing.copy(

--- a/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormViewModel.kt
+++ b/android/feature/seriesform/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/SeriesFormViewModel.kt
@@ -58,7 +58,7 @@ class SeriesFormViewModel @Inject constructor(
 
 	private fun handleSeriesFormAction(action: SeriesFormUiAction) {
 		when (action) {
-			SeriesFormUiAction.BackClicked -> dismiss()
+			SeriesFormUiAction.BackClicked -> handleBackClicked()
 			SeriesFormUiAction.DoneClicked -> saveSeries()
 			SeriesFormUiAction.ArchiveClicked -> setArchiveSeriesPrompt(isVisible = true)
 			SeriesFormUiAction.ConfirmArchiveClicked -> archiveSeries()
@@ -66,6 +66,8 @@ class SeriesFormViewModel @Inject constructor(
 			SeriesFormUiAction.AlleyClicked -> sendEvent(SeriesFormScreenEvent.EditAlley(alleyId = getFormUiState()?.alley?.id))
 			SeriesFormUiAction.DateClicked -> setDatePicker(isVisible = true)
 			SeriesFormUiAction.DatePickerDismissed -> setDatePicker(isVisible = false)
+			SeriesFormUiAction.DiscardChangesClicked -> dismiss()
+			SeriesFormUiAction.CancelDiscardChangesClicked -> setDiscardChangesDialog(isVisible = false)
 			is SeriesFormUiAction.NumberOfGamesChanged -> updateNumberOfGames(action.numberOfGames)
 			is SeriesFormUiAction.DateChanged -> updateDate(action.date)
 			is SeriesFormUiAction.PreBowlChanged -> updatePreBowl(action.preBowl)
@@ -106,6 +108,7 @@ class SeriesFormViewModel @Inject constructor(
 						isDatePickerVisible = false,
 						isShowingArchiveDialog = false,
 						isArchiveButtonEnabled = false,
+						isShowingDiscardChangesDialog = false,
 					),
 					topBar = SeriesFormTopBarUiState(
 						existingDate = null,
@@ -130,6 +133,7 @@ class SeriesFormViewModel @Inject constructor(
 						alley = series.alley,
 						isShowingArchiveDialog = false,
 						isArchiveButtonEnabled = true,
+						isShowingDiscardChangesDialog = false,
 					),
 					topBar = SeriesFormTopBarUiState(
 						existingDate = series.properties.date,
@@ -148,6 +152,21 @@ class SeriesFormViewModel @Inject constructor(
 			val alleyDetails = alleyId?.let { alleysRepository.getAlleyDetails(it).first() }
 			setFormUiState(uiState.copy(alley = alleyDetails))
 		}
+	}
+
+	private fun handleBackClicked() {
+		if (_uiState.value.hasAnyChanges()) {
+			setDiscardChangesDialog(isVisible = true)
+		} else {
+			dismiss()
+		}
+	}
+
+	private fun setDiscardChangesDialog(isVisible: Boolean) {
+		val state = getFormUiState() ?: return
+		setFormUiState(state.copy(
+			isShowingDiscardChangesDialog = isVisible,
+		))
 	}
 
 	private fun setDatePicker(isVisible: Boolean) {

--- a/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesForm.kt
+++ b/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesForm.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ca.josephroque.bowlingcompanion.core.common.utils.simpleFormat
 import ca.josephroque.bowlingcompanion.core.designsystem.components.ArchiveDialog
+import ca.josephroque.bowlingcompanion.core.designsystem.components.DiscardChangesDialog
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormRadioGroup
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.FormSection
 import ca.josephroque.bowlingcompanion.core.designsystem.components.form.PickableResourceCard
@@ -58,6 +59,13 @@ fun SeriesForm(
 			itemName = state.date.simpleFormat(),
 			onArchive = { onAction(SeriesFormUiAction.ConfirmArchiveClicked) },
 			onDismiss = { onAction(SeriesFormUiAction.DismissArchiveClicked) },
+		)
+	}
+
+	if (state.isShowingDiscardChangesDialog) {
+		DiscardChangesDialog(
+			onDiscardChanges = { onAction(SeriesFormUiAction.DiscardChangesClicked) },
+			onDismiss = { onAction(SeriesFormUiAction.CancelDiscardChangesClicked) },
 		)
 	}
 
@@ -345,6 +353,7 @@ private fun SeriesFormPreview() {
 				isDatePickerVisible = false,
 				isShowingArchiveDialog = false,
 				isArchiveButtonEnabled = true,
+				isShowingDiscardChangesDialog = false,
 			),
 			onAction = {},
 		)

--- a/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesFormUi.kt
+++ b/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesFormUi.kt
@@ -15,6 +15,7 @@ data class SeriesFormUiState(
 	val alley: AlleyDetails?,
 	val isShowingArchiveDialog: Boolean,
 	val isArchiveButtonEnabled: Boolean,
+	val isShowingDiscardChangesDialog: Boolean,
 )
 
 sealed interface SeriesFormUiAction {
@@ -24,6 +25,9 @@ sealed interface SeriesFormUiAction {
 	data object ArchiveClicked : SeriesFormUiAction
 	data object ConfirmArchiveClicked : SeriesFormUiAction
 	data object DismissArchiveClicked : SeriesFormUiAction
+
+	data object DiscardChangesClicked: SeriesFormUiAction
+	data object CancelDiscardChangesClicked: SeriesFormUiAction
 
 	data object AlleyClicked : SeriesFormUiAction
 


### PR DESCRIPTION
Fixes #433 

Shows discard changes modal when pressing back button in forms to save changes before exiting.