### PR TITLE
fix(ios): use darker warning color

### DIFF
--- a/ios/Approach/Sources/AssetsLibrary/Resources/Colors.xcassets/Warning/Default.colorset/Contents.json
+++ b/ios/Approach/Sources/AssetsLibrary/Resources/Colors.xcassets/Warning/Default.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.008",
-          "green" : "0.800",
-          "red" : "1.000"
+          "blue" : "0x00",
+          "green" : "0x67",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.008",
-          "green" : "0.800",
-          "red" : "1.000"
+          "blue" : "0x00",
+          "green" : "0x67",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Fixes #266 