### PR TITLE
Manual Series

### DIFF
--- a/android/core/data/src/main/java/ca/josephroque/bowlingcompanion/core/data/repository/OfflineFirstLeaguesRepository.kt
+++ b/android/core/data/src/main/java/ca/josephroque/bowlingcompanion/core/data/repository/OfflineFirstLeaguesRepository.kt
@@ -60,6 +60,7 @@ class OfflineFirstLeaguesRepository @Inject constructor(
 						preBowl = SeriesPreBowl.REGULAR,
 						excludeFromStatistics = ExcludeFromStatistics.INCLUDE,
 						alleyId = null,
+						manualScores = null,
 					),
 				)
 			}

--- a/android/core/data/src/main/java/ca/josephroque/bowlingcompanion/core/data/repository/OfflineFirstSeriesRepository.kt
+++ b/android/core/data/src/main/java/ca/josephroque/bowlingcompanion/core/data/repository/OfflineFirstSeriesRepository.kt
@@ -11,6 +11,8 @@ import ca.josephroque.bowlingcompanion.core.database.model.asEntity
 import ca.josephroque.bowlingcompanion.core.model.ArchivedSeries
 import ca.josephroque.bowlingcompanion.core.model.ExcludeFromStatistics
 import ca.josephroque.bowlingcompanion.core.model.GameCreate
+import ca.josephroque.bowlingcompanion.core.model.GameLockState
+import ca.josephroque.bowlingcompanion.core.model.GameScoringMethod
 import ca.josephroque.bowlingcompanion.core.model.SeriesCreate
 import ca.josephroque.bowlingcompanion.core.model.SeriesDetails
 import ca.josephroque.bowlingcompanion.core.model.SeriesListItem
@@ -51,10 +53,22 @@ class OfflineFirstSeriesRepository @Inject constructor(
 		transactionRunner {
 			seriesDao.insertSeries(series.asEntity())
 			val games = (0..<series.numberOfGames).map { index ->
+				val score = series.manualScores?.getOrNull(index)
 				GameCreate(
 					id = UUID.randomUUID(),
 					seriesId = series.id,
 					index = index,
+					score = score ?: 0,
+					locked = if (score != null) {
+						GameLockState.LOCKED
+					} else {
+						GameLockState.UNLOCKED
+					},
+					scoringMethod = if (score != null) {
+						GameScoringMethod.MANUAL
+					} else {
+						GameScoringMethod.BY_FRAME
+					},
 					excludeFromStatistics = series.excludeFromStatistics,
 				)
 			}

--- a/android/core/featureflags/src/main/java/ca/josephroque/bowlingcompanion/core/featureflags/FeatureFlag.kt
+++ b/android/core/featureflags/src/main/java/ca/josephroque/bowlingcompanion/core/featureflags/FeatureFlag.kt
@@ -22,6 +22,7 @@ enum class FeatureFlag(
 	DATA_EXPORT("DataExport", "2023-10-12", RolloutStage.RELEASE),
 	DATA_IMPORT("DataImport", "2023-10-13", RolloutStage.RELEASE),
 	PRE_BOWL_FORM("PreBowlForm", "2024-03-24", RolloutStage.RELEASE),
+	MANUAL_SERIES_FORM("ManualSeriesForm", "2024-03-28", RolloutStage.DEVELOPMENT),
 }
 
 fun FeatureFlag.isEnabled(): Boolean = if (BuildConfig.DEBUG) {

--- a/android/core/model/src/main/java/ca/josephroque/bowlingcompanion/core/model/Series.kt
+++ b/android/core/model/src/main/java/ca/josephroque/bowlingcompanion/core/model/Series.kt
@@ -86,6 +86,7 @@ data class SeriesCreate(
 	val appliedDate: LocalDate?,
 	val numberOfGames: Int,
 	val preBowl: SeriesPreBowl,
+	val manualScores: List<Int>?,
 	val excludeFromStatistics: ExcludeFromStatistics,
 	val alleyId: UUID?,
 )

--- a/android/feature/overview/src/main/java/ca/josephroque/bowlingcompanion/feature/overview/quickplay/QuickPlayViewModel.kt
+++ b/android/feature/overview/src/main/java/ca/josephroque/bowlingcompanion/feature/overview/quickplay/QuickPlayViewModel.kt
@@ -143,6 +143,7 @@ class QuickPlayViewModel @Inject constructor(
 						preBowl = SeriesPreBowl.REGULAR,
 						excludeFromStatistics = ExcludeFromStatistics.INCLUDE,
 						alleyId = null,
+						manualScores = null,
 					),
 				)
 

--- a/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesForm.kt
+++ b/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesForm.kt
@@ -5,16 +5,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ca.josephroque.bowlingcompanion.core.common.utils.simpleFormat
@@ -75,6 +79,22 @@ fun SeriesForm(
 			alley = state.alley,
 			onClick = { onAction(SeriesFormUiAction.AlleyClicked) },
 		)
+
+		HorizontalDivider()
+
+		if (state.isManualSeriesEnabled && state.isCreatingManualSeries != null) {
+			ManualSeriesSection(
+				isCreatingManualSeries = state.isCreatingManualSeries,
+				manualScores = state.manualScores,
+				onManualScoreChanged = { index, score ->
+					onAction(SeriesFormUiAction.ManualScoreChanged(index, score))
+				},
+				onIsCreatingManualSeriesChanged = {
+					onAction(SeriesFormUiAction.IsCreatingManualSeriesChanged(it))
+				},
+				modifier = Modifier.padding(top = 16.dp),
+			)
+		}
 
 		HorizontalDivider()
 
@@ -175,6 +195,51 @@ private fun AlleySection(alley: AlleyDetails?, onClick: () -> Unit) {
 }
 
 @Composable
+private fun ManualSeriesSection(
+	isCreatingManualSeries: Boolean,
+	manualScores: List<Int>,
+	onManualScoreChanged: (Int, String) -> Unit,
+	onIsCreatingManualSeriesChanged: (Boolean) -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	FormSection(
+		titleResourceId = R.string.series_form_manual_series,
+		footerResourceId = R.string.series_form_manual_series_description,
+		modifier = modifier,
+	) {
+		FormSwitch(
+			titleResourceId = R.string.series_form_manual_series_manual,
+			isChecked = isCreatingManualSeries,
+			onCheckChanged = onIsCreatingManualSeriesChanged,
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(horizontal = 16.dp),
+		)
+
+		if (isCreatingManualSeries) {
+			manualScores.forEachIndexed { index, score ->
+				OutlinedTextField(
+					value = score.toString(),
+					onValueChange = { onManualScoreChanged(index, it) },
+					singleLine = true,
+					keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+					label = {
+						Text(
+							stringResource(R.string.series_form_manual_series_game_score, index + 1),
+							style = MaterialTheme.typography.bodyMedium,
+						)
+					},
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(horizontal = 16.dp)
+						.padding(bottom = if (index == manualScores.size - 1) 0.dp else 16.dp),
+				)
+			}
+		}
+	}
+}
+
+@Composable
 private fun PreBowlSection(
 	preBowl: SeriesPreBowl,
 	isPreBowlFormEnabled: Boolean,
@@ -188,9 +253,7 @@ private fun PreBowlSection(
 	onAppliedDatePickerDismissed: () -> Unit,
 	modifier: Modifier = Modifier,
 ) {
-	FormSection(
-		modifier = modifier,
-	) {
+	FormSection(modifier = modifier) {
 		FormRadioGroup(
 			titleResourceId = R.string.series_form_pre_bowl,
 			subtitleResourceId = R.string.series_form_section_pre_bowl_description,
@@ -304,6 +367,9 @@ private fun SeriesFormPreview() {
 				isArchiveButtonEnabled = true,
 				isShowingDiscardChangesDialog = false,
 				isPreBowlFormEnabled = true,
+				isCreatingManualSeries = true,
+				manualScores = listOf(100, 200),
+				isManualSeriesEnabled = true,
 			),
 			onAction = {},
 		)

--- a/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesFormUi.kt
+++ b/android/feature/seriesform/ui/src/main/java/ca/josephroque/bowlingcompanion/feature/seriesform/ui/SeriesFormUi.kt
@@ -19,7 +19,10 @@ data class SeriesFormUiState(
 	val isShowingArchiveDialog: Boolean,
 	val isArchiveButtonEnabled: Boolean,
 	val isShowingDiscardChangesDialog: Boolean,
+	val isCreatingManualSeries: Boolean?,
+	val manualScores: List<Int>,
 	val isPreBowlFormEnabled: Boolean,
+	val isManualSeriesEnabled: Boolean,
 )
 
 sealed interface SeriesFormUiAction {
@@ -47,6 +50,11 @@ sealed interface SeriesFormUiAction {
 	data class AppliedDateChanged(val date: LocalDate) : SeriesFormUiAction
 	data class ExcludeFromStatisticsChanged(
 		val excludeFromStatistics: ExcludeFromStatistics,
+	) : SeriesFormUiAction
+	data class IsCreatingManualSeriesChanged(val isCreatingManualSeries: Boolean) : SeriesFormUiAction
+	data class ManualScoreChanged(
+		val index: Int,
+		val score: String,
 	) : SeriesFormUiAction
 }
 

--- a/android/feature/seriesform/ui/src/main/res/values/strings.xml
+++ b/android/feature/seriesform/ui/src/main/res/values/strings.xml
@@ -9,6 +9,11 @@
 
 	<string name="series_form_bowling_alley">Bowling Alley</string>
 
+	<string name="series_form_manual_series">Manual Series</string>
+	<string name="series_form_manual_series_description">Add a series without recording the frames. The scores will count towards your average and high series. You can still edit the game details later.</string>
+	<string name="series_form_manual_series_manual">Set manual scores for games?</string>
+	<string name="series_form_manual_series_game_score">Game %1$d score</string>
+
 	<string name="series_form_section_pre_bowl_description">Pre-bowls are excluded from statistics until you use them. You can easily find your recorded pre-bowls in the series list, and change their date for when you plan to use them.</string>
 	<string name="series_form_pre_bowl">Pre-Bowling?</string>
 	<string name="series_form_pre_bowl_no">No</string>

--- a/ios/Approach/Sources/DatabaseModelsLibrary/Series+Database.swift
+++ b/ios/Approach/Sources/DatabaseModelsLibrary/Series+Database.swift
@@ -93,17 +93,25 @@ extension Series {
 		withPreferredGear preferredGear: [Gear.Database],
 		startIndex: Int,
 		count: Int,
+		manualScores: [Int]?,
 		db: GRDB.Database
 	) throws {
 		@Dependency(\.uuid) var uuid
 		for index in (startIndex..<startIndex + count) {
+			let manualScore: Int?
+			if let manualScores {
+				manualScore = index - startIndex < manualScores.count ? manualScores[index - startIndex] : nil
+			} else {
+				manualScore = nil
+			}
+
 			let game = Game.Database(
 				seriesId: seriesId,
 				id: uuid(),
 				index: index,
-				score: 0,
-				locked: .open,
-				scoringMethod: .byFrame,
+				score: manualScore ?? 0,
+				locked: manualScore == nil ? .open : .locked,
+				scoringMethod: manualScore == nil ? .byFrame : .manual,
 				excludeFromStatistics: .init(from: excludeFromStatistics),
 				duration: 0,
 				archivedOn: nil

--- a/ios/Approach/Sources/FeatureFlagsLibrary/FeatureFlags.swift
+++ b/ios/Approach/Sources/FeatureFlagsLibrary/FeatureFlags.swift
@@ -11,11 +11,13 @@ extension FeatureFlag {
 	public static let purchases = Self(name: "purchase", introduced: "2023-09-15", stage: .disabled)
 	public static let dataImport = Self(name: "dataImport", introduced: "2023-09-17", stage: .development)
 	public static let preBowlForm = Self(name: "preBowlForm", introduced: "2024-03-23", stage: .release)
+	public static let manualSeries = Self(name: "manualSeries", introduced: "2024-03-28", stage: .development)
 
 	public static let allFlags: [Self] = [
 		.alleyAndGearAverages,
 		.dataImport,
 		.developerOptions,
+		.manualSeries,
 		.opponentDetails,
 		.preBowlForm,
 		.proSubscription,

--- a/ios/Approach/Sources/LeaguesRepository/LeaguesRepository+Live.swift
+++ b/ios/Approach/Sources/LeaguesRepository/LeaguesRepository+Live.swift
@@ -137,6 +137,7 @@ extension LeaguesRepository: DependencyKey {
 									withPreferredGear: preferredGear,
 									startIndex: 0,
 									count: numberOfGames,
+									manualScores: nil,
 									db: db
 								)
 							}

--- a/ios/Approach/Sources/SeriesEditorFeature/ManualSeriesGameEditor.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/ManualSeriesGameEditor.swift
@@ -1,0 +1,66 @@
+import ComposableArchitecture
+import FeatureActionLibrary
+import ModelsLibrary
+import StringsLibrary
+import SwiftUI
+
+@Reducer
+public struct ManualSeriesGameEditor: Reducer {
+	@ObservableState
+	public struct State: Identifiable, Equatable {
+		public let id: Game.ID
+		public let index: Int
+		public var score: Int = 0
+
+		public init(id: Game.ID, index: Int) {
+			self.id = id
+			self.index = index
+		}
+	}
+
+	public enum Action: FeatureAction, ViewAction, BindableAction {
+		@CasePathable public enum View { case doNothing }
+		@CasePathable public enum Delegate { case doNothing }
+		@CasePathable public enum Internal { case doNothing }
+
+		case view(View)
+		case delegate(Delegate)
+		case `internal`(Internal)
+		case binding(BindingAction<State>)
+	}
+
+	public var body: some ReducerOf<Self> {
+		BindingReducer()
+
+		Reduce<State, Action> { state, action in
+			switch action {
+			case .view(.doNothing):
+				return .none
+
+			case .internal(.doNothing):
+				return .none
+
+			case .binding(\.score):
+				state.score = min(max(state.score, 0), Game.MAXIMUM_SCORE)
+				return .none
+
+			case .delegate, .binding:
+				return .none
+			}
+		}
+	}
+}
+
+@ViewAction(for: ManualSeriesGameEditor.self)
+public struct ManualSeriesGameEditorView: View {
+	@Bindable public var store: StoreOf<ManualSeriesGameEditor>
+
+	public var body: some View {
+		TextField(
+			Strings.Series.Editor.Fields.Manual.scoreForGameOrdinal(store.index + 1),
+			value: $store.score,
+			formatter: NumberFormatter()
+		)
+		.keyboardType(.numberPad)
+	}
+}

--- a/ios/Approach/Sources/SeriesEditorFeature/SeriesEditorView.swift
+++ b/ios/Approach/Sources/SeriesEditorFeature/SeriesEditorView.swift
@@ -20,70 +20,15 @@ public struct SeriesEditorView: View {
 
 	public var body: some View {
 		FormView(store: store.scope(state: \.form, action: \.internal.form)) {
-			Section(Strings.Editor.Fields.Details.title) {
-				Stepper(
-					Strings.Series.Editor.Fields.numberOfGames(store.numberOfGames),
-					value: $store.numberOfGames,
-					in: League.NUMBER_OF_GAMES_RANGE
-				)
-				.disabled(store.isEditing)
+			detailsSection
 
-				DatePicker(
-					Strings.Series.Properties.date,
-					selection: $store.date,
-					displayedComponents: [.date]
-				)
-				.datePickerStyle(.graphical)
+			if store.isManualSeriesEnabled && !store.isEditing {
+				manualSection
 			}
 
 			locationSection
-
-			Section {
-				Picker(
-					Strings.Series.Editor.Fields.PreBowl.label,
-					selection: $store.preBowl.animation()
-				) {
-					ForEach(Series.PreBowl.allCases) {
-						Text(String(describing: $0)).tag($0)
-					}
-				}
-
-				if store.isPreBowlFormEnabled && store.preBowl == .preBowl {
-					Toggle(
-						Strings.Series.Editor.Fields.PreBowl.usePreBowl,
-						isOn: $store.isUsingPreBowl.animation()
-					)
-
-					if store.isUsingPreBowl {
-						DatePicker(
-							Strings.Series.Editor.Fields.PreBowl.date,
-							selection: $store.appliedDate,
-							displayedComponents: [.date]
-						)
-						.datePickerStyle(.graphical)
-					}
-				}
-			} header: {
-				Text(Strings.Series.Editor.Fields.PreBowl.title)
-			} footer: {
-				Text(Strings.Series.Editor.Fields.PreBowl.help)
-			}
-
-			Section {
-				Picker(
-					Strings.Series.Editor.Fields.ExcludeFromStatistics.label,
-					selection: $store.excludeFromStatistics
-				) {
-					ForEach(Series.ExcludeFromStatistics.allCases) {
-						Text(String(describing: $0)).tag($0)
-					}
-				}
-				.disabled(store.isExcludeFromStatisticsToggleEnabled)
-			} header: {
-				Text(Strings.Series.Editor.Fields.ExcludeFromStatistics.title)
-			} footer: {
-				excludeFromStatisticsHelp
-			}
+			preBowlSection
+			statisticsSection
 		}
 		.interactiveDismissDisabled(store.isDismissDisabled)
 		.onAppear { send(.onAppear) }
@@ -93,6 +38,43 @@ public struct SeriesEditorView: View {
 			ResourcePickerView(store: store) { alley in
 				Alley.View(alley)
 			}
+		}
+	}
+
+	private var detailsSection: some View {
+		Section(Strings.Editor.Fields.Details.title) {
+			Stepper(
+				Strings.Series.Editor.Fields.numberOfGames(store.numberOfGames),
+				value: $store.numberOfGames,
+				in: League.NUMBER_OF_GAMES_RANGE
+			)
+			.disabled(store.isEditing)
+
+			DatePicker(
+				Strings.Series.Properties.date,
+				selection: $store.date,
+				displayedComponents: [.date]
+			)
+			.datePickerStyle(.graphical)
+		}
+	}
+
+	private var manualSection: some View {
+		Section {
+			Toggle(
+				Strings.Series.Editor.Fields.Manual.setScoresManually,
+				isOn: $store.isCreatingManualSeries.animation()
+			)
+
+			if store.isCreatingManualSeries {
+				ForEach(store.scope(state: \.manualScores, action: \.internal.manualSeriesGame), id: \.state.id) {
+					ManualSeriesGameEditorView(store: $0)
+				}
+			}
+		} header: {
+			Text(Strings.Series.Editor.Fields.Manual.title)
+		} footer: {
+			Text(Strings.Series.Editor.Fields.Manual.footer)
 		}
 	}
 
@@ -122,6 +104,57 @@ public struct SeriesEditorView: View {
 			Text(Strings.Series.Editor.Fields.Alley.help)
 		}
 		.listRowSeparator(.hidden)
+	}
+
+	private var preBowlSection: some View {
+		Section {
+			Picker(
+				Strings.Series.Editor.Fields.PreBowl.label,
+				selection: $store.preBowl.animation()
+			) {
+				ForEach(Series.PreBowl.allCases) {
+					Text(String(describing: $0)).tag($0)
+				}
+			}
+
+			if store.isPreBowlFormEnabled && store.preBowl == .preBowl {
+				Toggle(
+					Strings.Series.Editor.Fields.PreBowl.usePreBowl,
+					isOn: $store.isUsingPreBowl.animation()
+				)
+
+				if store.isUsingPreBowl {
+					DatePicker(
+						Strings.Series.Editor.Fields.PreBowl.date,
+						selection: $store.appliedDate,
+						displayedComponents: [.date]
+					)
+					.datePickerStyle(.graphical)
+				}
+			}
+		} header: {
+			Text(Strings.Series.Editor.Fields.PreBowl.title)
+		} footer: {
+			Text(Strings.Series.Editor.Fields.PreBowl.help)
+		}
+	}
+
+	private var statisticsSection: some View {
+		Section {
+			Picker(
+				Strings.Series.Editor.Fields.ExcludeFromStatistics.label,
+				selection: $store.excludeFromStatistics
+			) {
+				ForEach(Series.ExcludeFromStatistics.allCases) {
+					Text(String(describing: $0)).tag($0)
+				}
+			}
+			.disabled(store.isExcludeFromStatisticsToggleEnabled)
+		} header: {
+			Text(Strings.Series.Editor.Fields.ExcludeFromStatistics.title)
+		} footer: {
+			excludeFromStatisticsHelp
+		}
 	}
 
 	@ViewBuilder private var excludeFromStatisticsHelp: some View {

--- a/ios/Approach/Sources/SeriesRepository/SeriesRepository+Live.swift
+++ b/ios/Approach/Sources/SeriesRepository/SeriesRepository+Live.swift
@@ -173,6 +173,7 @@ extension SeriesRepository: DependencyKey {
 								withPreferredGear: preferredGear,
 								startIndex: 0,
 								count: series.numberOfGames,
+								manualScores: series.manualScores,
 								db: db
 							)
 						}
@@ -225,6 +226,7 @@ extension SeriesRepository: DependencyKey {
 								withPreferredGear: preferredGear,
 								startIndex: series.maxGameIndex < 0 ? 0 : series.maxGameIndex + 1,
 								count: count,
+								manualScores: nil,
 								db: db
 							)
 						}

--- a/ios/Approach/Sources/SeriesRepositoryInterface/Models/Series+Create.swift
+++ b/ios/Approach/Sources/SeriesRepositoryInterface/Models/Series+Create.swift
@@ -13,6 +13,7 @@ extension Series {
 		public var excludeFromStatistics: ExcludeFromStatistics
 		public var numberOfGames: Int
 		public var location: Alley.Summary?
+		public var manualScores: [Int]?
 
 		public static func `default`(withId: UUID, onDate: Date, inLeague: League.SeriesHost) -> Self {
 			.init(
@@ -23,7 +24,8 @@ extension Series {
 				preBowl: .regular,
 				excludeFromStatistics: .include,
 				numberOfGames: inLeague.defaultNumberOfGames ?? League.DEFAULT_NUMBER_OF_GAMES,
-				location: inLeague.alley
+				location: inLeague.alley,
+				manualScores: nil
 			)
 		}
 

--- a/ios/Approach/Sources/StringsLibrary/Strings+Generated.swift
+++ b/ios/Approach/Sources/StringsLibrary/Strings+Generated.swift
@@ -1086,6 +1086,18 @@ public enum Strings {
           /// Statistics
           public static let title = Strings.tr("Localizable", "series.editor.fields.excludeFromStatistics.title", fallback: "Statistics")
         }
+        public enum Manual {
+          /// Add a series without recording the frames. The scores will count towards your average and high series. You can still edit the game details later.
+          public static let footer = Strings.tr("Localizable", "series.editor.fields.manual.footer", fallback: "Add a series without recording the frames. The scores will count towards your average and high series. You can still edit the game details later.")
+          /// Game %d score
+          public static func scoreForGameOrdinal(_ p1: Int) -> String {
+            return Strings.tr("Localizable", "series.editor.fields.manual.scoreForGameOrdinal", p1, fallback: "Game %d score")
+          }
+          /// Set scores manually?
+          public static let setScoresManually = Strings.tr("Localizable", "series.editor.fields.manual.setScoresManually", fallback: "Set scores manually?")
+          /// Manual Recording
+          public static let title = Strings.tr("Localizable", "series.editor.fields.manual.title", fallback: "Manual Recording")
+        }
         public enum PreBowl {
           /// Date to apply
           public static let date = Strings.tr("Localizable", "series.editor.fields.preBowl.date", fallback: "Date to apply")

--- a/ios/Approach/Sources/StringsLibrary/en.lproj/Localizable.strings
+++ b/ios/Approach/Sources/StringsLibrary/en.lproj/Localizable.strings
@@ -179,6 +179,10 @@
 "series.properties.preBowl.regular" = "Regular";
 "series.properties.excludeFromStatistics.include" = "Include";
 "series.properties.excludeFromStatistics.exclude" = "Exclude";
+"series.editor.fields.manual.title" = "Manual Recording";
+"series.editor.fields.manual.setScoresManually" = "Set scores manually?";
+"series.editor.fields.manual.scoreForGameOrdinal" = "Game %d score";
+"series.editor.fields.manual.footer" = "Add a series without recording the frames. The scores will count towards your average and high series. You can still edit the game details later.";
 "series.editor.fields.alley.title" = "Alley";
 "series.editor.fields.alley.help" = "This is where you plan on bowling this series.";
 "series.editor.fields.alley.lanes" = "Lanes";


### PR DESCRIPTION
Fixes #299 

Introduces menu option in series form to set manual scores when series is created. Not visible in editing.

| | iOS | Android |
|---|---|---|
| Creating | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-28 at 18 54 40](https://github.com/autoreleasefool/approach/assets/6619581/a5077fe9-f6be-4787-ac2f-bdb2019ce969) | ![Screenshot 2024-03-28 at 6 55 34 PM](https://github.com/autoreleasefool/approach/assets/6619581/95cf195d-90a9-4899-842b-bf93516d06c0) |
| Editing | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-28 at 18 56 44](https://github.com/autoreleasefool/approach/assets/6619581/be8ed116-6a18-4c17-84f9-659b732ce6c6) | ![Screenshot 2024-03-28 at 6 56 29 PM](https://github.com/autoreleasefool/approach/assets/6619581/bb6e6c88-36c7-48a4-b45d-c31cdcce1720) |
