### PR TITLE
fix(android): better calculation of game in progress to resume

### DIFF
--- a/android/core/data/src/main/java/ca/josephroque/bowlingcompanion/core/data/repository/GamesRepository.kt
+++ b/android/core/data/src/main/java/ca/josephroque/bowlingcompanion/core/data/repository/GamesRepository.kt
@@ -27,7 +27,6 @@ interface GamesRepository {
 	fun getGamesFromSeries(series: List<SeriesID>, gameIndex: Int): Flow<List<GameListItemBySeries>>
 	fun getShareableGame(gameId: GameID): Flow<ShareableGame>
 
-	suspend fun isGameInProgress(): Boolean
 	suspend fun getGameInProgress(): GameInProgress?
 
 	suspend fun setGameScoringMethod(gameId: GameID, scoringMethod: GameScoringMethod, score: Int)


### PR DESCRIPTION
Should fix #583 

Instead of blindly dismissing an "in progress" game when the user navigates back, we now save it as a resumable game if it hasn't explicitly been completed.

Furthermore, detection of whether the game in progress is resumable is better now. We check the size of the series, and if there were multiple series, and only don't offer to resume if the bowler was on the last frame of the last game.

Might end up making the "Resume" show up more often than it needs to, but that's probably a better trade-off